### PR TITLE
fix failing hr_attendance_analysis tests

### DIFF
--- a/hr_attendance_analysis/hr_attendance.py
+++ b/hr_attendance_analysis/hr_attendance.py
@@ -194,10 +194,10 @@ class HrAttendance(orm.Model):
             employee = self.pool.get('hr.employee').browse(
                 cr, uid, employee_id, context=context)
             if active_contract_ids:
-                message = _('Too many active contracts for employee %s at date %s')
+                msg = _('Too many active contracts for employee %s at date %s')
             else:
-                message = _('No active contracts for employee %s at date %s')
-            raise orm.except_orm(_('Error'), message % (employee.name, date))
+                msg = _('No active contracts for employee %s at date %s')
+            raise orm.except_orm(_('Error'), msg % (employee.name, date))
         else:
             contract = contract_pool.browse(
                 cr, uid, active_contract_ids[0], context=context)

--- a/hr_attendance_analysis/hr_attendance.py
+++ b/hr_attendance_analysis/hr_attendance.py
@@ -190,17 +190,18 @@ class HrAttendance(orm.Model):
             ('trial_date_end', '!=', False),
             ('trial_date_end', '>=', date),
         ], context=context)
-        if len(active_contract_ids) > 1:
+        if len(active_contract_ids) != 1:
             employee = self.pool.get('hr.employee').browse(
                 cr, uid, employee_id, context=context)
-            raise orm.except_orm(_('Error'), _(
-                'Too many active contracts for employee %s'
-            ) % employee.name)
-        if active_contract_ids:
+            if active_contract_ids:
+                message = _('Too many active contracts for employee %s at date %s')
+            else:
+                message = _('No active contracts for employee %s at date %s')
+            raise orm.except_orm(_('Error'), message % (employee.name, date))
+        else:
             contract = contract_pool.browse(
                 cr, uid, active_contract_ids[0], context=context)
             return contract.working_hours
-        return active_contract_ids
 
     def _ceil_rounding(self, rounding, datetime):
         minutes = (datetime.minute / 60.0

--- a/hr_attendance_analysis/hr_attendance.py
+++ b/hr_attendance_analysis/hr_attendance.py
@@ -190,18 +190,17 @@ class HrAttendance(orm.Model):
             ('trial_date_end', '!=', False),
             ('trial_date_end', '>=', date),
         ], context=context)
-        if len(active_contract_ids) != 1:
+        if len(active_contract_ids) > 1:
             employee = self.pool.get('hr.employee').browse(
                 cr, uid, employee_id, context=context)
-            if active_contract_ids:
-                msg = _('Too many active contracts for employee %s at date %s')
-            else:
-                msg = _('No active contracts for employee %s at date %s')
+            msg = _('Too many active contracts for employee %s at date %s')
             raise orm.except_orm(_('Error'), msg % (employee.name, date))
-        else:
+        elif active_contract_ids:
             contract = contract_pool.browse(
                 cr, uid, active_contract_ids[0], context=context)
             return contract.working_hours
+        else:
+            return orm.browse_null()
 
     def _ceil_rounding(self, rounding, datetime):
         minutes = (datetime.minute / 60.0

--- a/hr_attendance_analysis/test/attendances.yml
+++ b/hr_attendance_analysis/test/attendances.yml
@@ -1,4 +1,10 @@
 -
+  Change the contract of the Employee to ensure the test will happen during the contract
+-
+ !python {model: hr.contract}: |
+   import time
+   self.write(cr, uid, [ref('al_contract')], {'date_start': time.strftime('%Y-%m-01')}, context=context)
+-
   First of all, Employee Sign's In.
 -
   !record {model: hr.attendance, id: hr_attendance_0}:


### PR DESCRIPTION
the tests would fail when run after the 11th of the month
because then the hr.contract created by the demo data would not be valid at the
time of the timesheet.
- change the start date of the contract in the tests
- fix `HrAttendance.get_default_calendar` to raise an exception when no contract
  is found instead of returning an empty list which caused an `AttributeError`
