### PR TITLE
fix pep8

### DIFF
--- a/hr_attendance_analysis/wizard/print_calendar_report.py
+++ b/hr_attendance_analysis/wizard/print_calendar_report.py
@@ -80,8 +80,8 @@ class wizard_calendar_report(orm.TransientModel):
     def print_calendar(self, cr, uid, ids, context=None):
         if context is None:
             context = {}
-        attendance_pool = self.pool.get('hr.attendance')
-        holidays_pool = self.pool.get('hr.holidays')
+        attendance_obj = self.pool.get('hr.attendance')
+        holidays_obj = self.pool.get('hr.holidays')
         precision = self.pool.get('res.users').browse(
             cr, uid, uid, context=context).company_id.working_time_precision
         active_tz = pytz.timezone(
@@ -135,28 +135,28 @@ class wizard_calendar_report(orm.TransientModel):
                 str_current_date_end = (
                     current_date_end_utc.strftime('%Y-%m-%d %H:%M:%S'))
 
-                attendance_ids = attendance_pool.search(cr, uid, [
+                attendance_ids = attendance_obj.search(cr, uid, [
                     ('employee_id', '=', int(employee_id)),
                     ('name', '>=', str_current_date_beginning),
                     ('name', '<=', str_current_date_end),
                     ('action', '=', 'sign_in'),
                 ], context=context)
                 # computing attendance totals
-                for attendance in attendance_pool.browse(
+                for attendance in attendance_obj.browse(
                         cr, uid, attendance_ids, context=context):
-                    current_total_attendances = attendance_pool.time_sum(
+                    current_total_attendances = attendance_obj.time_sum(
                         current_total_attendances, attendance.duration)
-                    current_total_overtime = attendance_pool.time_sum(
+                    current_total_overtime = attendance_obj.time_sum(
                         current_total_overtime,
                         attendance.outside_calendar_duration)
-                    current_total_inside_calendar = attendance_pool.time_sum(
+                    current_total_inside_calendar = attendance_obj.time_sum(
                         current_total_inside_calendar,
                         attendance.inside_calendar_duration)
                 # printing up to 4 attendances
                 if len(attendance_ids) < 5:
                     count = 1
                     for attendance in sorted(
-                        attendance_pool.browse(
+                        attendance_obj.browse(
                             cr, uid, attendance_ids, context=context
                         ),
                         key=lambda x: x['name']
@@ -185,7 +185,7 @@ class wizard_calendar_report(orm.TransientModel):
                 days_by_employee[employee_id][str_current_date][
                     'overtime'
                 ] = current_total_overtime
-                reference_calendar = attendance_pool.get_reference_calendar(
+                reference_calendar = attendance_obj.get_reference_calendar(
                     cr, uid, int(employee_id), date=str_current_date,
                     context=context)
                 # computing due total
@@ -213,7 +213,7 @@ class wizard_calendar_report(orm.TransientModel):
                                 )
                             ):
                                 calendar_attendance_duration = (
-                                    attendance_pool.time_difference(
+                                    attendance_obj.time_difference(
                                         calendar_attendance.hour_from,
                                         calendar_attendance.hour_to,
                                         help_message=(
@@ -226,13 +226,13 @@ class wizard_calendar_report(orm.TransientModel):
                                         _("%s: 'Work to' is < 'Work from'")
                                         % calendar_attendance.name)
                                 current_total_due = \
-                                    attendance_pool.time_sum(
+                                    attendance_obj.time_sum(
                                         current_total_due,
                                         calendar_attendance_duration)
                 days_by_employee[employee_id][
                     str_current_date]['due'] = current_total_due
                 # computing leaves
-                holidays_ids = holidays_pool.search(cr, uid, [
+                holidays_ids = holidays_obj.search(cr, uid, [
                     '&', '&', '|',
                     # leave begins today
                     '&',
@@ -250,7 +250,7 @@ class wizard_calendar_report(orm.TransientModel):
                     ('state', '=', 'validate'),
                     ('employee_id', '=', int(employee_id)),
                 ], context=context)
-                for holiday in holidays_pool.browse(
+                for holiday in holidays_obj.browse(
                         cr, uid, holidays_ids, context=context):
                     date_from = datetime.strptime(
                         holiday.date_from, '%Y-%m-%d %H:%M:%S')
@@ -268,19 +268,19 @@ class wizard_calendar_report(orm.TransientModel):
                         tzinfo=pytz.utc).astimezone(active_tz)
                     duration_delta = date_to - date_from
                     duration = (
-                        attendance_pool.total_seconds(duration_delta)
+                        attendance_obj.total_seconds(duration_delta)
                         / 60.0 / 60.0
                     )
                     intervals_within = 0
                     splitted_holidays = (
-                        attendance_pool.split_interval_time_by_precision(
+                        attendance_obj.split_interval_time_by_precision(
                             date_from, duration, precision)
                     )
                     counter = 0
                     for atomic_holiday in splitted_holidays:
                         counter += 1
                         centered_holiday = (
-                            attendance_pool.mid_time_interval(
+                            attendance_obj.mid_time_interval(
                                 atomic_holiday[0],
                                 delta=atomic_holiday[1],
                             )
@@ -289,7 +289,7 @@ class wizard_calendar_report(orm.TransientModel):
                         # schedule
                         weekday_char = str(
                             unichr(centered_holiday.weekday() + 48))
-                        matched_schedule_ids = attendance_pool.matched_schedule(
+                        matched_schedule_ids = attendance_obj.matched_schedule(
                             cr, uid,
                             centered_holiday,
                             weekday_char,
@@ -313,7 +313,7 @@ class wizard_calendar_report(orm.TransientModel):
                     days_by_employee[employee_id][str_current_date][
                         'leaves'
                     ] = days_by_employee[employee_id][str_current_date]['due']
-                due_minus_leaves = attendance_pool.time_difference(
+                due_minus_leaves = attendance_obj.time_difference(
                     current_total_leaves, current_total_due,
                     help_message='Employee ID %s. Date %s' % (
                         employee_id, str_current_date))
@@ -323,7 +323,7 @@ class wizard_calendar_report(orm.TransientModel):
                 else:
                     days_by_employee[employee_id][str_current_date][
                         'negative'
-                        ] = attendance_pool.time_difference(
+                        ] = attendance_obj.time_difference(
                         current_total_inside_calendar, due_minus_leaves,
                         help_message='Employee ID %s. Date %s' % (
                             employee_id, str_current_date))
@@ -348,27 +348,27 @@ class wizard_calendar_report(orm.TransientModel):
             }
             for str_date in days_by_employee[employee_id]:
                 totals_by_employee[employee_id]['total_attendances'] = \
-                    attendance_pool.time_sum(
+                    attendance_obj.time_sum(
                         totals_by_employee[employee_id]['total_attendances'],
                         days_by_employee[employee_id][str_date]['attendances'])
                 totals_by_employee[employee_id]['total_overtime'] = \
-                    attendance_pool.time_sum(
+                    attendance_obj.time_sum(
                         totals_by_employee[employee_id]['total_overtime'],
                         days_by_employee[employee_id][str_date]['overtime'])
                 totals_by_employee[employee_id]['total_negative'] = \
-                    attendance_pool.time_sum(
+                    attendance_obj.time_sum(
                         totals_by_employee[employee_id]['total_negative'],
                         days_by_employee[employee_id][str_date]['negative'])
                 totals_by_employee[employee_id]['total_leaves'] = \
-                    attendance_pool.time_sum(
+                    attendance_obj.time_sum(
                         totals_by_employee[employee_id]['total_leaves'],
                         days_by_employee[employee_id][str_date]['leaves'])
                 totals_by_employee[employee_id]['total_due'] = \
-                    attendance_pool.time_sum(
+                    attendance_obj.time_sum(
                         totals_by_employee[employee_id]['total_due'],
                         days_by_employee[employee_id][str_date]['due'])
                 # computing overtime types
-                reference_calendar = attendance_pool.get_reference_calendar(
+                reference_calendar = attendance_obj.get_reference_calendar(
                     cr, uid, int(employee_id), date=str_date, context=context)
                 if reference_calendar:
                     if reference_calendar.overtime_type_ids:
@@ -386,66 +386,66 @@ class wizard_calendar_report(orm.TransientModel):
                                 if current_overtime <= overtime_type.limit or \
                                         not overtime_type.limit:
                                     emp['total_types'][overtime_type.name] = \
-                                        attendance_pool.time_sum(
+                                        attendance_obj.time_sum(
                                             emp['total_types']
                                             [overtime_type.name],
                                             current_overtime)
                                     current_overtime = 0.0
                                 else:
                                     emp['total_types'][overtime_type.name] = \
-                                        attendance_pool.time_sum(
+                                        attendance_obj.time_sum(
                                             emp['total_types']
                                             [overtime_type.name],
                                             overtime_type.limit)
                                     current_overtime = \
-                                        attendance_pool.time_difference(
+                                        attendance_obj.time_difference(
                                             overtime_type.limit,
                                             current_overtime)
                 days_by_employee[employee_id][str_date][
                     'attendances'
-                ] = attendance_pool.float_time_convert(
+                ] = attendance_obj.float_time_convert(
                     days_by_employee[employee_id][str_date]['attendances'])
                 days_by_employee[employee_id][str_date][
                     'overtime'
-                ] = attendance_pool.float_time_convert(
+                ] = attendance_obj.float_time_convert(
                     days_by_employee[employee_id][str_date]['overtime'])
                 days_by_employee[employee_id][str_date][
                     'negative'
-                ] = attendance_pool.float_time_convert(
+                ] = attendance_obj.float_time_convert(
                     days_by_employee[employee_id][str_date]['negative'])
                 days_by_employee[employee_id][str_date][
                     'leaves'
-                ] = attendance_pool.float_time_convert(
+                ] = attendance_obj.float_time_convert(
                     days_by_employee[employee_id][str_date]['leaves'])
                 days_by_employee[employee_id][str_date][
                     'due'
-                ] = attendance_pool.float_time_convert(
+                ] = attendance_obj.float_time_convert(
                     days_by_employee[employee_id][str_date]['due'])
             totals_by_employee[employee_id][
                 'total_attendances'
-            ] = attendance_pool.float_time_convert(
+            ] = attendance_obj.float_time_convert(
                 totals_by_employee[employee_id]['total_attendances'])
             totals_by_employee[employee_id][
                 'total_overtime'
-            ] = attendance_pool.float_time_convert(
+            ] = attendance_obj.float_time_convert(
                 totals_by_employee[employee_id]['total_overtime'])
             totals_by_employee[employee_id][
                 'total_negative'
-            ] = attendance_pool.float_time_convert(
+            ] = attendance_obj.float_time_convert(
                 totals_by_employee[employee_id]['total_negative'])
             totals_by_employee[employee_id][
                 'total_leaves'
-            ] = attendance_pool.float_time_convert(
+            ] = attendance_obj.float_time_convert(
                 totals_by_employee[employee_id]['total_leaves'])
             totals_by_employee[employee_id][
                 'total_due'
-            ] = attendance_pool.float_time_convert(
+            ] = attendance_obj.float_time_convert(
                 totals_by_employee[employee_id]['total_due'])
             for overtime_type in \
                     totals_by_employee[employee_id]['total_types']:
                 totals_by_employee[employee_id]['total_types'][
                     overtime_type
-                ] = attendance_pool.float_time_convert(
+                ] = attendance_obj.float_time_convert(
                     totals_by_employee[employee_id]['total_types']
                     [overtime_type])
         datas = {'ids': employee_ids}

--- a/hr_timesheet_fulfill/wizard/timesheet_fulfill.py
+++ b/hr_timesheet_fulfill/wizard/timesheet_fulfill.py
@@ -41,7 +41,8 @@ class HrTimesheetFulfill(orm.TransientModel):
         'date_from': fields.date('Date From', required=True),
         'date_to': fields.date('Date To', required=True),
         'description': fields.char('Description', size=100, required=True),
-        'nb_hours': fields.float('Hours per Day', digits=(2, 2), required=True),
+        'nb_hours': fields.float('Hours per Day', digits=(2, 2),
+                                 required=True),
         'analytic_account_id': fields.many2one(
             'account.analytic.account', 'Analytic Account', required=True,
             domain="[('type', '<>', 'view'),"

--- a/hr_timesheet_holidays/wizard/holidays_import.py
+++ b/hr_timesheet_holidays/wizard/holidays_import.py
@@ -80,12 +80,17 @@ class HolidaysImport(orm.TransientModel):
         date_to_str = date_to.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
         date_utc_to = get_utc_datetime(date_to, local_tz).strftime(
             DEFAULT_SERVER_DATETIME_FORMAT)
-        cr.execute("select id, date_from, date_to, name from hr_holidays where "
-                   "(((date_from <= %s and date_to >= %s and date_to <= %s) or "
-                   "(date_from >= %s and date_from <= %s and date_to >= %s) or "
-                   "(date_from >= %s and date_from <= %s and date_to >= %s and "
+        cr.execute("select id, date_from, date_to, name from hr_holidays "
+                   "where "
+                   "(((date_from <= %s and date_to >= %s and date_to <= %s) "
+                   "or "
+                   "(date_from >= %s and date_from <= %s and date_to >= %s) "
+                   "or "
+                   "(date_from >= %s and date_from <= %s and date_to >= %s "
+                   "and "
                    "date_to <= %s) or "
-                   "(date_from <= %s and date_to >= %s)) and user_id = %s and "
+                   "(date_from <= %s and date_to >= %s)) and user_id = %s "
+                   "and "
                    "state = 'validate')",
                    (date_utc_from, date_utc_from, date_utc_to,
                     date_utc_from, date_utc_to, date_utc_to,
@@ -140,7 +145,9 @@ class HolidaysImport(orm.TransientModel):
         attendance_obj = self.pool['hr.attendance']
         anl_account_obj = self.pool['account.analytic.account']
         timesheet_id = context['active_id']
-        timesheet = timesheet_obj.browse(cr, uid, timesheet_id, context=context)
+        timesheet = timesheet_obj.browse(cr, uid,
+                                         timesheet_id,
+                                         context=context)
         employee_id = employee_obj.search(
             cr, uid, [('user_id', '=', uid)], context=context)[0]
         if timesheet.state != 'draft':
@@ -171,11 +178,13 @@ class HolidaysImport(orm.TransientModel):
             anl_account = anl_account_obj.browse(cr, uid, analytic_account_id,
                                                  context)
             if holiday.date_from < timesheet.date_from:
-                dt_ts_from = get_utc_start_of_day(timesheet.date_from, local_tz)
+                dt_ts_from = get_utc_start_of_day(timesheet.date_from,
+                                                  local_tz)
                 holiday.date_from = dt_ts_from.strftime(
                     DEFAULT_SERVER_DATETIME_FORMAT)
             if holiday.date_to > timesheet.date_to:
-                dt_ts_to = get_utc_end_of_day(timesheet.date_to, local_tz)
+                dt_ts_to = get_utc_end_of_day(timesheet.date_to,
+                                              local_tz)
                 holiday.date_to = dt_ts_to.strftime(
                     DEFAULT_SERVER_DATETIME_FORMAT)
             nb_days = get_number_days_between_dates(holiday.date_from,
@@ -203,8 +212,10 @@ class HolidaysImport(orm.TransientModel):
                               ('user_id', '=', uid)])
                 if not existing_ts_ids:
                     unit_id = al_ts_obj._getEmployeeUnit(cr, uid, context)
-                    product_id = al_ts_obj._getEmployeeProduct(cr, uid, context)
-                    journal_id = al_ts_obj._getAnalyticJournal(cr, uid, context)
+                    product_id = al_ts_obj._getEmployeeProduct(cr, uid,
+                                                               context)
+                    journal_id = al_ts_obj._getAnalyticJournal(cr, uid,
+                                                               context)
                     holiday_day = {
                         'name': holiday.name or _('Holidays'),
                         'date': str_dt_current,

--- a/hr_timesheet_reminder/company.py
+++ b/hr_timesheet_reminder/company.py
@@ -88,7 +88,7 @@ class ResCompany(orm.Model):
         return periods
 
     def get_last_period_dates(self, cr, uid, company, date, context=None):
-        """ return the start date and end date of the last period to display """
+        """return the start date and end date of the last period to display"""
         # return the first day and last day of the month
         if company.timesheet_range == 'month':
             start_date = date


### PR DESCRIPTION
line max length now 79 char, not 80

one of the refactoring involved renaming xxxx_pool variables to xxxx_obj which is the generally used convention and 1 char shorter. 
