### PR TITLE
Fix attendance interpose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ python:
   - "2.7"
 
 env:
-  - VERSION="7.0" ODOO_REPO="odoo/odoo"
-  - VERSION="7.0" ODOO_REPO="OCA/OCB"
-
+  - VERSION="7.0" ODOO_REPO="odoo/odoo" EXCLUDE="hr_timesheet_improvement,hr_attendance_analysis"
+  - VERSION="7.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1"
+  - VERSION="7.0" ODOO_REPO="OCA/OCB" EXCLUDE="hr_timesheet_improvement,hr_attendance_analysis"
+  - VERSION="7.0" ODOO_REPO="OCA/OCB" UNIT_TEST="1"
 virtualenv:
   system_site_packages: true
 

--- a/hr_timesheet_improvement/hr_attendance.py
+++ b/hr_timesheet_improvement/hr_attendance.py
@@ -29,22 +29,22 @@ class HrAttendance(orm.Model):
     _inherit = "hr.attendance"
 
     def _default_date(self, cr, uid, context=None):
-        sheet_id = context.get('sheet_id')
+        sheet_id = context['sheet_id')
         if not sheet_id:
             return time.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
-        ts_obj = self.pool.get('hr_timesheet_sheet.sheet')
+        ts_obj = self.pool['hr_timesheet_sheet.sheet']
         timesheet = ts_obj.browse(cr, uid, sheet_id, context=context)
         dates = [a.name for a in timesheet.attendances_ids]
         if not dates:
             return timesheet.date_from
         return max(dates)
 
-    def _altern_si_so(self, cr, uid, ids, context=None):
+    def check_altern_si_so(self, cr, uid, ids, context=None):
         """ Alternance sign_in/sign_out check.
             Previous (if exists) must be of opposite action.
             Next (if exists) must be of opposite action.
         """
-        sheet_obj = self.pool.get('hr_timesheet_sheet.sheet')
+        sheet_obj = self.pool['hr_timesheet_sheet.sheet']
         for att in self.browse(cr, uid, ids, context=context):
             sheet_id = sheet_obj.search(
                 cr, uid, [
@@ -82,6 +82,13 @@ class HrAttendance(orm.Model):
             # first attendance must be sign_in
             if (not prev_atts) and (not next_atts) and att.action != 'sign_in':
                 return False
+        return True
+
+    def _altern_si_so(self, cr, uid, ids, context=None):
+        """ This standard countraint is deactivated and replaced
+            by a test (check_altern_si_so) when the user confirm his timesheet
+            (Button Confirm)
+        """
         return True
 
     _constraints = [

--- a/hr_timesheet_improvement/hr_attendance.py
+++ b/hr_timesheet_improvement/hr_attendance.py
@@ -29,7 +29,7 @@ class HrAttendance(orm.Model):
     _inherit = "hr.attendance"
 
     def _default_date(self, cr, uid, context=None):
-        sheet_id = context['sheet_id')
+        sheet_id = context.get('sheet_id')
         if not sheet_id:
             return time.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
         ts_obj = self.pool['hr_timesheet_sheet.sheet']

--- a/hr_timesheet_improvement/hr_timesheet.py
+++ b/hr_timesheet_improvement/hr_timesheet.py
@@ -30,13 +30,13 @@ class HrAnalyticTimesheet(orm.Model):
     _order = "date_aal DESC, account_name ASC"
 
     def _get_account_analytic_line(self, cr, uid, ids, context=None):
-        ts_line_ids = self.pool.get('hr.analytic.timesheet').search(
-            cr, uid, [('line_id', 'in', ids)])
+        ts_line_ids = self.pool['hr.analytic.timesheet'].search(
+            cr, uid, [('line_id', 'in', ids)], context=context)
         return ts_line_ids
 
     def _get_account_analytic_account(self, cr, uid, ids, context=None):
-        ts_line_ids = self.pool.get('hr.analytic.timesheet').search(
-            cr, uid, [('account_id', 'in', ids)])
+        ts_line_ids = self.pool['hr.analytic.timesheet'].search(
+            cr, uid, [('account_id', 'in', ids)], context=context)
         return ts_line_ids
 
     _columns = {
@@ -56,3 +56,27 @@ class HrAnalyticTimesheet(orm.Model):
                 'hr.analytic.timesheet': (lambda self, cr, uid, ids,
                                           context=None: ids, None, 10)}),
     }
+
+
+class HrTimesheetsheet(orm.Model):
+    """
+    Set order by line date and analytic account name instead of id
+    We create related stored values as _order cannot be used
+    on inherited columns
+    """
+    _inherit = "hr_timesheet_sheet.sheet"
+
+    def button_confirm(self, cr, uid, ids, context=None):
+        attendances_obj = self.pool['hr.attendance']
+        for sheet in self.browse(cr, uid, ids, context=context):
+            ids_attendances = attendances_obj.search(cr, uid,
+                                                     [('sheet_id',
+                                                       '=',
+                                                       sheet.id)],
+                                                     context=context)
+            attendances_obj.check_altern_si_so(cr, uid,
+                                               ids_attendances,
+                                               context=context)
+        return super(HrTimesheetsheet, self).button_confirm(cr, uid,
+                                                            ids,
+                                                            context=context)


### PR DESCRIPTION
Validating attendance by attendance generate a lot of errors
in case you interpose attendance between other.
So I remove this check in the constraint and set the validation
into the confirm button of the timesheet.
