### PR TITLE
fix pylint warnings in 7.0 branch

### DIFF
--- a/hr_attendance_analysis/hr_attendance.py
+++ b/hr_attendance_analysis/hr_attendance.py
@@ -130,10 +130,10 @@ class HrAttendance(orm.Model):
             res.append((start_datetime, precision))
         return res
 
-    def datetime_to_hour(self, datetime):
+    def datetime_to_hour(self, datetime_):
         hour = (
-            datetime.hour + datetime.minute / 60.0
-            + datetime.second / 3600.0
+            datetime_.hour + datetime_.minute / 60.0
+            + datetime_.second / 3600.0
         )
         return hour
 
@@ -142,12 +142,12 @@ class HrAttendance(orm.Model):
 
     def matched_schedule(
             self, cr, uid,
-            datetime, weekday_char, calendar_id,
+            datetime_, weekday_char, calendar_id,
             context=None
     ):
         calendar_attendance_pool = self.pool.get(
             'resource.calendar.attendance')
-        datetime_hour = self.datetime_to_hour(datetime)
+        datetime_hour = self.datetime_to_hour(datetime_)
         matched_schedule_ids = calendar_attendance_pool.search(
             cr,
             uid,
@@ -155,7 +155,7 @@ class HrAttendance(orm.Model):
                 '&',
                 '|',
                 ('date_from', '=', False),
-                ('date_from', '<=', datetime.date()),
+                ('date_from', '<=', datetime_.date()),
                 '|',
                 ('dayofweek', '=', False),
                 ('dayofweek', '=', weekday_char),
@@ -202,14 +202,14 @@ class HrAttendance(orm.Model):
         else:
             return orm.browse_null()
 
-    def _ceil_rounding(self, rounding, datetime):
-        minutes = (datetime.minute / 60.0
-                   + datetime.second / 3600.0)
+    def _ceil_rounding(self, rounding, datetime_):
+        minutes = (datetime_.minute / 60.0
+                   + datetime_.second / 3600.0)
         return math.ceil(minutes * rounding) / rounding
 
-    def _floor_rounding(self, rounding, datetime):
-        minutes = (datetime.minute / 60.0
-                   + datetime.second / 3600.0)
+    def _floor_rounding(self, rounding, datetime_):
+        minutes = (datetime_.minute / 60.0
+                   + datetime_.second / 3600.0)
         return math.floor(minutes * rounding) / rounding
 
     def _get_attendance_duration(self, cr, uid, ids, field_name, arg,

--- a/hr_attendance_analysis/hr_contract.py
+++ b/hr_attendance_analysis/hr_contract.py
@@ -33,10 +33,10 @@ from openerp.osv import orm
 class hr_contract(orm.Model):
     _inherit = 'hr.contract'
 
-    def copy(self, cr, uid, id, defaults, context=None):
+    def copy(self, cr, uid, contract_id, defaults, context=None):
         """ When duplicate a contract set the start date to the last end
         date + 1 day. If the last end date is False, do nothing"""
-        contract = self.browse(cr, uid, id, context=context)
+        contract = self.browse(cr, uid, contract_id, context=context)
         end_date_contract_id = self.search(
             cr, uid,
             [('employee_id', '=', contract.employee_id.id), ], limit=1,
@@ -53,5 +53,5 @@ class hr_contract(orm.Model):
             defaults['date_end'] = False
             defaults['trial_date_start'] = False
             defaults['trial_date_end'] = False
-        return super(hr_contract, self).copy(cr, uid, id, defaults,
+        return super(hr_contract, self).copy(cr, uid, contract_id, defaults,
                                              context=context)

--- a/hr_attendance_analysis/report/__init__.py
+++ b/hr_attendance_analysis/report/__init__.py
@@ -18,4 +18,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-import calendar_report
+from . import calendar_report

--- a/hr_attendance_analysis/wizard/__init__.py
+++ b/hr_attendance_analysis/wizard/__init__.py
@@ -20,4 +20,4 @@
 #
 ##############################################################################
 
-import print_calendar_report
+from . import print_calendar_report

--- a/hr_attendance_analysis/wizard/print_calendar_report.py
+++ b/hr_attendance_analysis/wizard/print_calendar_report.py
@@ -66,7 +66,7 @@ class wizard_calendar_report(orm.TransientModel):
 
     _name = "attendance_analysis.wizard.calendar_report"
 
-    def on_change_month(self, cr, uid, id, str_month, year):
+    def on_change_month(self, cr, uid, id_, str_month, year):
         res = {}
         if year and str_month:
             month = int(str_month)

--- a/hr_timesheet_fulfill/wizard/__init__.py
+++ b/hr_timesheet_fulfill/wizard/__init__.py
@@ -1,4 +1,3 @@
+# -*- coding: utf-8 -*-
 
-import timesheet_fulfill
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+from . import timesheet_fulfill

--- a/hr_timesheet_holidays/wizard/__init__.py
+++ b/hr_timesheet_holidays/wizard/__init__.py
@@ -18,4 +18,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-import holidays_import
+from . import holidays_import

--- a/hr_timesheet_improvement/hr_attendance.py
+++ b/hr_timesheet_improvement/hr_attendance.py
@@ -38,9 +38,6 @@ class HrAttendance(orm.Model):
         if not dates:
             return timesheet.date_from
         return max(dates)
-    """
-    Check sign in signout in the same timesheet only
-    """
 
     def _altern_si_so(self, cr, uid, ids, context=None):
         """ Alternance sign_in/sign_out check.

--- a/hr_timesheet_print/report/__init__.py
+++ b/hr_timesheet_print/report/__init__.py
@@ -17,4 +17,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-import timesheet_report
+from . import timesheet_report

--- a/hr_timesheet_reminder/report/__init__.py
+++ b/hr_timesheet_reminder/report/__init__.py
@@ -19,4 +19,4 @@
 #
 ##############################################################################
 
-import timesheet_status
+from . import timesheet_status

--- a/hr_timesheet_reminder/wizard/reminder_config.py
+++ b/hr_timesheet_reminder/wizard/reminder_config.py
@@ -55,9 +55,9 @@ class ReminderConfig(orm.TransientModel):
          'Periodicity must be greater than 0 ', ['interval_number']),
     ]
 
-    def default_get(self, cr, uid, fields, context=None):
+    def default_get(self, cr, uid, field_list, context=None):
         res = super(ReminderConfig, self).default_get(
-            cr, uid, fields, context=context)
+            cr, uid, field_list, context=context)
         data = self.pool['hr.timesheet.reminder'].get_config(
             cr, uid, context=context)
         res.update(data)

--- a/timesheet_task/project_task.py
+++ b/timesheet_task/project_task.py
@@ -65,14 +65,14 @@ class ProjectTask(orm.Model):
                 res[task.id]['progress'] = 100.0
         return res
 
-    def _store_set_values(self, cr, uid, ids, fields, context=None):
+    def _store_set_values(self, cr, uid, ids, field_list, context=None):
         # Hack to avoid redefining most of function fields of project.project
         # model. This is mainly due to the fact that orm _store_set_values use
         # direct access to database. So when modify a line the
         # _store_set_values as it uses cursor directly to update tasks
         # project triggers on task are not called
         res = super(ProjectTask, self)._store_set_values(
-            cr, uid, ids, fields, context=context)
+            cr, uid, ids, field_list, context=context)
         for row in self.browse(cr, SUPERUSER_ID, ids, context=context):
             if row.project_id:
                 project = row.project_id


### PR DESCRIPTION
renamed datetime (variable) to datetime_ to not shadow the datetime module

renamed fields to field_list for the same reason, and id to id_ too. 

used relative imports
