### PR TITLE
[FIX] reset selected task on account change

### DIFF
--- a/hr_timesheet_task/static/src/js/timesheet.js
+++ b/hr_timesheet_task/static/src/js/timesheet.js
@@ -187,6 +187,9 @@ openerp.hr_timesheet_task = function(instance) {
                         },
                     },
                 });
+                // reset value previously selected
+                self.task_m2o.set_value(false);
+                self.task_m2o.render_value();
             });
 
             self.$(".oe_timesheet_weekly_add_row button").click(function() {


### PR DESCRIPTION
In the WeeklyTimesheet when account_m2o loses focus and value changes reset the task_m2o value
