### PR TITLE
[IMP] [8.0] hr_timesheet: add onchange to validate the relation between a project and a task.

### DIFF
--- a/timesheet_task/project_task.py
+++ b/timesheet_task/project_task.py
@@ -202,7 +202,7 @@ class HrAnalyticTimesheet(orm.Model):
         '''
         res = super(HrAnalyticTimesheet, self)\
             .on_change_account_id(account_id=account_id, user_id=user_id)
-            
+
         if 'value' not in res:
             res['value'] = {}
 

--- a/timesheet_task/project_task.py
+++ b/timesheet_task/project_task.py
@@ -20,7 +20,7 @@
 ##############################################################################
 
 from openerp.osv import orm, fields
-from openerp import SUPERUSER_ID
+from openerp import api, SUPERUSER_ID
 from openerp.tools.translate import _
 
 TASK_WATCHERS = [
@@ -194,6 +194,27 @@ class HrAnalyticTimesheet(orm.Model):
             self, cr, uid, ids, names, arg, context=None):
         """Ensure all hr_analytic_timesheet_id is always False"""
         return dict.fromkeys(ids, False)
+
+    @api.multi
+    def on_change_account_id(self, account_id, context=None):
+        ''' Validate the relation between the project and the task.
+            Task must be belong to the project.
+        '''
+        to_invoice = False
+        task_id = False
+        if account_id:
+            project_obj = self.env["project.project"]
+            projects = project_obj.search([('analytic_account_id',
+                                            '=', account_id)])
+            if projects:
+                assert len(projects) == 1
+                project = projects[0]
+                to_invoice = project.to_invoice.id
+                valid_task_ids = [task.id for task in project.tasks]
+                if len(valid_task_ids) == 1:
+                    task_id = valid_task_ids[0]
+
+        return {'value': {'task_id': task_id, 'to_invoice': to_invoice}}
 
     _columns = {
         'hr_analytic_timesheet_id': fields.function(

--- a/timesheet_task/project_task.py
+++ b/timesheet_task/project_task.py
@@ -196,11 +196,16 @@ class HrAnalyticTimesheet(orm.Model):
         return dict.fromkeys(ids, False)
 
     @api.multi
-    def on_change_account_id(self, account_id, context=None):
+    def on_change_account_id(self, account_id, user_id=False):
         ''' Validate the relation between the project and the task.
             Task must be belong to the project.
         '''
-        to_invoice = False
+        res = super(HrAnalyticTimesheet, self)\
+            .on_change_account_id(account_id=account_id, user_id=user_id)
+            
+        if 'value' not in res:
+            res['value'] = {}
+
         task_id = False
         if account_id:
             project_obj = self.env["project.project"]
@@ -209,11 +214,11 @@ class HrAnalyticTimesheet(orm.Model):
             if projects:
                 assert len(projects) == 1
                 project = projects[0]
-                to_invoice = project.to_invoice.id
                 if len(project.tasks) == 1:
                     task_id = project.tasks[0].id
 
-        return {'value': {'task_id': task_id, 'to_invoice': to_invoice}}
+        res['value']['task_id'] = task_id
+        return res
 
     _columns = {
         'hr_analytic_timesheet_id': fields.function(

--- a/timesheet_task/project_task.py
+++ b/timesheet_task/project_task.py
@@ -210,9 +210,8 @@ class HrAnalyticTimesheet(orm.Model):
                 assert len(projects) == 1
                 project = projects[0]
                 to_invoice = project.to_invoice.id
-                valid_task_ids = [task.id for task in project.tasks]
-                if len(valid_task_ids) == 1:
-                    task_id = valid_task_ids[0]
+                if len(project.tasks) == 1:
+                    task_id = project.tasks[0].id
 
         return {'value': {'task_id': task_id, 'to_invoice': to_invoice}}
 


### PR DESCRIPTION
Add a method "on_change_account_id" to validate the relation between a project and a task. 

Without this PR, if a user modify a project on a existing line, the task will not be modified. This will cause an error when saving (the task must belong to the timesheet line project).
