### PR TITLE
hr_timesheet_task: filter out closed project from project selection

### DIFF
--- a/hr_timesheet_task/static/src/js/timesheet.js
+++ b/hr_timesheet_task/static/src/js/timesheet.js
@@ -145,6 +145,7 @@ openerp.hr_timesheet_task = function(instance) {
                     type: "many2one",
                     domain: [
                         ['type','in',['normal', 'contract']],
+                        ['state', '<>', 'close'],
                         ['use_timesheets','=',1],
                     ],
                     context: {

--- a/hr_timesheet_task/static/src/js/timesheet.js
+++ b/hr_timesheet_task/static/src/js/timesheet.js
@@ -145,7 +145,7 @@ openerp.hr_timesheet_task = function(instance) {
                     type: "many2one",
                     domain: [
                         ['type','in',['normal', 'contract']],
-                        ['state', '<>', 'close'],
+                        ['state', '!=', 'close'],
                         ['use_timesheets','=',1],
                     ],
                     context: {


### PR DESCRIPTION
A user should not be able to select a closed project on a timesheet like in standard (https://github.com/odoo/odoo/commit/46b112f1295a4302b81d043b49df869a1aa3affe).
