### PR TITLE
Fix filter 'Today' for attendances analysis

### DIFF
--- a/hr_attendance_analysis/hr_attendance_view.xml
+++ b/hr_attendance_analysis/hr_attendance_view.xml
@@ -38,7 +38,7 @@
             <field name="model">hr.attendance</field>
             <field name="arch" type="xml">
                 <search string="Hr Attendance Search">
-                    <filter icon="terp-go-today" string="Today" name="today" domain="[('name::date','=',current_date)]" />
+                    <filter icon="terp-go-today" string="Today" name="today" domain="[('name','&gt;=',current_date),('name','&lt;=',current_date)]" />
                     <separator orientation="vertical"/>
                     <field name="employee_id"/>
                     <field name="name" string="Start date time"/>


### PR DESCRIPTION
This PR fixes the following error: `ValueError: Invalid field 'name::date'`

As pointed out by @marcok in https://github.com/OCA/hr-timesheet/issues/27
