### PR TITLE
make 7.0 green on runbot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
-addons:
-  apt:
-    packages:
-      - expect-dev  # provides unbuffer utility
-      - python-lxml # because pip installation is slow
-
 language: python
 
 python:
   - "2.7"
 
 env:
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" EXCLUDE="hr_timesheet_improvement,hr_attendance_analysis"
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1"
-  - VERSION="7.0" ODOO_REPO="OCA/OCB" EXCLUDE="hr_timesheet_improvement,hr_attendance_analysis"
-  - VERSION="7.0" ODOO_REPO="OCA/OCB" UNIT_TEST="1"
+  - VERSION="8.0" LINT_CHECK="1"
+  - VERSION="7.0" ODOO_REPO="odoo/odoo" EXCLUDE="hr_timesheet_improvement,hr_attendance_analysis" LINT_CHECK="0"
+  - VERSION="7.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1"  LINT_CHECK="0"
+  - VERSION="7.0" ODOO_REPO="OCA/OCB" EXCLUDE="hr_timesheet_improvement,hr_attendance_analysis" LINT_CHECK="0"
+  - VERSION="7.0" ODOO_REPO="OCA/OCB" UNIT_TEST="1" LINT_CHECK="0"
+
 virtualenv:
   system_site_packages: true
+
+addons:
+  apt:
+    packages:
+      - expect-dev  # provides unbuffer utility
+      - python-lxml # because pip installation is slow
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
@@ -23,7 +25,6 @@ install:
   - travis_install_nightly ${VERSION}
 
 script:
-  - travis_run_flake8
   - travis_run_tests ${VERSION}
 
 after_success:

--- a/hr_timesheet_fulfill/wizard/timesheet_fulfill_view.xml
+++ b/hr_timesheet_fulfill/wizard/timesheet_fulfill_view.xml
@@ -51,7 +51,6 @@
       <field name="model">hr_timesheet_sheet.sheet</field>
       <field name="name">Fill in Timesheet</field>
       <field eval="'ir.actions.act_window,%d'%action_hr_timesheet_fulfill" name="value"/>
-      <field eval="True" name="object"/>
     </record>
 
   </data>

--- a/hr_timesheet_holidays/wizard/holidays_import_view.xml
+++ b/hr_timesheet_holidays/wizard/holidays_import_view.xml
@@ -30,7 +30,6 @@
       <field name="model">hr_timesheet_sheet.sheet</field>
       <field name="name">Import Holidays</field>
       <field eval="'ir.actions.act_window,%d'%action_hr_timesheet_holidays_import" name="value"/>
-      <field eval="True" name="object"/>
     </record>
 
   </data>


### PR DESCRIPTION
by removing a non existent field in an ir.value record
which was causing

WARNING openerp.osv.orm: No such field(s) in model ir.values: object.
