### PR TITLE
remove pytz from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ addons:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
-      - pytz # because pip installation is really slow
 
 language: python
 


### PR DESCRIPTION
package not whitelisted and the name is python-tz anyway
