### PR TITLE
[7.0] [ADD] Module "hr_timesheet_sheet period" to default the timesheet start and end date to the pay period

### DIFF
--- a/hr_timesheet_sheet_period/__init__.py
+++ b/hr_timesheet_sheet_period/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent
+#    (<http://www.eficent.com>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import models

--- a/hr_timesheet_sheet_period/__openerp__.py
+++ b/hr_timesheet_sheet_period/__openerp__.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent
+#    (<http://www.eficent.com>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': "HR Timesheet Sheet based on Payroll Period",
+    'version': '1.0',
+    'category': 'Human Resources',
+    'description': """
+HR Timesheet Sheet based on Payroll Period
+==========================================
+
+This module was written to extend the human resources capabilities of Odoo,
+and allows to create timesheets with start and end dates matching with the
+payroll period.
+
+
+Installation
+============
+
+This module depends on module 'hr_period', found in OCA 'hr' repository.
+See: https://github.com/OCA/hr
+
+Configuration
+=============
+
+This module does not require any additional configuration.
+
+Usage
+=====
+
+No specific usage instructions are required.
+
+Known issues / Roadmap
+======================
+
+No issues have been identified.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+""",
+    'author': "Eficent,Odoo Community Association (OCA)",
+    'website': 'http://www.eficent.com',
+    'license': 'AGPL-3',
+    "depends": ['hr_period'],
+    "data": [],
+    'test': [],
+    "demo": [],
+    "active": False,
+    "installable": True
+}

--- a/hr_timesheet_sheet_period/__openerp__.py
+++ b/hr_timesheet_sheet_period/__openerp__.py
@@ -81,8 +81,10 @@ To contribute to this module, please visit http://odoo-community.org.
     'author': "Eficent,Odoo Community Association (OCA)",
     'website': 'http://www.eficent.com',
     'license': 'AGPL-3',
-    "depends": ['hr_period'],
-    "data": [],
+    "depends": ['hr_period', 'hr_timesheet_sheet'],
+    "data": [
+        'views/hr_timesheet_sheet_view.xml',
+    ],
     'test': [],
     "demo": [],
     "active": False,

--- a/hr_timesheet_sheet_period/__openerp__.py
+++ b/hr_timesheet_sheet_period/__openerp__.py
@@ -41,12 +41,14 @@ See: https://github.com/OCA/hr
 Configuration
 =============
 
-This module does not require any additional configuration.
+Create first the Payroll Fiscal Years and Payroll
+Periods from 'Human Resources > Configuration > Payroll'
 
 Usage
 =====
-
-No specific usage instructions are required.
+When the user goes to 'Human Resources > Time Tracking > My current
+timesheet', the application will attempt to create a new timesheet using as
+start and end dates the Pay Period corresponding to today's date.
 
 Known issues / Roadmap
 ======================

--- a/hr_timesheet_sheet_period/models/__init__.py
+++ b/hr_timesheet_sheet_period/models/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent
+#    (<http://www.eficent.com>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import hr_timesheet_sheet

--- a/hr_timesheet_sheet_period/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_period/models/hr_timesheet_sheet.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from datetime import datetime
+from openerp.osv import fields, osv, orm
+
+
+class HrTimesheetSheet(orm.Model):
+    _inherit = "hr_timesheet_sheet.sheet"
+
+    def _get_current_pay_period(self, cr, uid, context=None):
+        period_obj = self.pool['hr.period']
+        date_today = datetime.today().strftime('%Y-%m-%d')
+        period_ids = period_obj.search(cr, uid,
+                                       [('date_start', '<=', date_today),
+                                        ('date_stop', '>=', date_today)],
+                                       context=context)
+        if period_ids:
+            return period_ids[0]
+        else:
+            return False
+
+    def _default_date_from(self, cr, uid, context=None):
+        res = super(HrTimesheetSheet, self)._default_date_from(cr, uid,
+                                                               context=context)
+        period_id = self._get_current_pay_period(cr, uid, context=context)
+        period_obj = self.pool['hr.period']
+        if period_id:
+            return period_obj.browse(cr, uid, period_id,
+                                     context=context).date_start
+        else:
+            return res
+
+    def _default_date_to(self, cr, uid, context=None):
+        res = super(HrTimesheetSheet, self)._default_date_to(cr, uid,
+                                                             context=context)
+        period_id = self._get_current_pay_period(cr, uid, context=context)
+        period_obj = self.pool['hr.period']
+        if period_id:
+            return period_obj.browse(cr, uid, period_id,
+                                     context=context).date_stop
+        else:
+            return res
+
+    _defaults = {
+        'date_from': _default_date_from,
+        'date_to': _default_date_to,
+    }

--- a/hr_timesheet_sheet_period/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_sheet_period/views/hr_timesheet_sheet_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="hr_timesheet_sheet_form" model="ir.ui.view">
+            <field name="name">hr.timesheet.sheet.form</field>
+            <field name="model">hr_timesheet_sheet.sheet</field>
+            <field name="inherit_id"
+                   ref="hr_timesheet_sheet.hr_timesheet_sheet_form"/>
+            <field name="arch" type="xml">
+                <field name="name" position="before">
+                    <field name="hr_period_id"
+                           on_change="onchange_pay_period(hr_period_id)"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/hr_timesheet_sheet_period/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_sheet_period/views/hr_timesheet_sheet_view.xml
@@ -15,5 +15,17 @@
             </field>
         </record>
 
+        <record id="view_hr_timesheet_sheet_filter" model="ir.ui.view">
+            <field name="name">hr_timesheet_sheet.sheet.filter</field>
+            <field name="model">hr_timesheet_sheet.sheet</field>
+            <field name="inherit_id"
+                   ref="hr_timesheet_sheet.view_hr_timesheet_sheet_filter"/>
+            <field name="arch" type="xml">
+                <field name="date_from" position="after">
+                    <field name="hr_period_id"/>
+                </field>
+            </field>
+        </record>
+
     </data>
 </openerp>


### PR DESCRIPTION
# HR Timesheet Sheet based on Payroll Period

This module was written to extend the human resources capabilities of Odoo,
and allows to create timesheets with start and end dates matching with the
payroll period.
# Installation

This module depends on module 'hr_period', found in OCA 'hr' repository.
See: https://github.com/OCA/hr
# Configuration

Create first the Payroll Fiscal Years and Payroll
Periods from 'Human Resources > Configuration > Payroll'
# Usage

When the user goes to 'Human Resources > Time Tracking > My current
timesheet', the application will attempt to create a new timesheet using as
start and end dates the Pay Period corresponding to today's date.
