### PR TITLE
Add 'readonly' to related fields to avoid recomputation for all lines

### DIFF
--- a/hr_timesheet_improvement/hr_timesheet.py
+++ b/hr_timesheet_improvement/hr_timesheet.py
@@ -30,7 +30,7 @@ class HrAnalyticTimesheet(models.Model):
     _order = "date_aal DESC, account_name ASC"
 
     date_aal = fields.Date(related='line_id.date',
-                           store=True)
+                           store=True, readonly=True)
 
     account_name = fields.Char(related='account_id.name',
-                               store=True)
+                               store=True, readonly=True)


### PR DESCRIPTION
This PR is to avoid an issue raised by a customer : since the related field was not readonly, the account name was modified by creating a new timesheet line, and hence recomputed all timesheet lines with the same account.
