### PR TITLE
[8.0] [hr_timesheet_sheet_period] migration to v8

### DIFF
--- a/hr_timesheet_sheet_period/README.rst
+++ b/hr_timesheet_sheet_period/README.rst
@@ -7,7 +7,8 @@ HR Timesheet Sheet based on Payroll Period
 ==========================================
 
 This module allows to create timesheets with start and end dates matching with the
-payroll period.
+payroll period of the schedule pay that is specified in the contract of the 
+employee or if not then will match the nearest payroll period.
 
 Configuration
 =============
@@ -25,7 +26,7 @@ as per the Schedule Pay mentioned in the Employee's contract.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/117/9.0
+   :target: https://runbot.odoo-community.org/runbot/117/8.0
 
 
 Bug Tracker
@@ -39,6 +40,11 @@ help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------

--- a/hr_timesheet_sheet_period/README.rst
+++ b/hr_timesheet_sheet_period/README.rst
@@ -1,0 +1,62 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==========================================
+HR Timesheet Sheet based on Payroll Period
+==========================================
+
+This module allows to create timesheets with start and end dates matching with the
+payroll period.
+
+Configuration
+=============
+
+Create first the Payroll Fiscal Years and Payroll
+Periods from 'Human Resources > Configuration > Payroll'
+
+Usage
+=====
+
+When the user goes to 'Human Resources > Time Tracking > My current
+timesheet', the application will attempt to create a new timesheet using
+start and end dates of the Pay Period corresponding to today's date 
+as per the Schedule Pay mentioned in the Employee's contract.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/117/9.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/hr-timesheet/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/hr_timesheet_sheet_period/__init__.py
+++ b/hr_timesheet_sheet_period/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# Copyright 2016 Serpent Consulting Services Pvt. Ltd.
+#   (<http://www.serpentcs.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import models

--- a/hr_timesheet_sheet_period/__openerp__.py
+++ b/hr_timesheet_sheet_period/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# Copyright 2016 Serpent Consulting Services Pvt. Ltd.
+#   (<http://www.serpentcs.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': "HR Timesheet Sheet based on Payroll Period",
+    'version': '8.0.1.0.0',
+    'category': 'Human Resources',
+    "author": "Eficent,"
+              "SerpentCS,"
+              "Odoo Community Association (OCA)",
+    'website': 'http://www.eficent.com',
+    'license': 'AGPL-3',
+    "depends": ['hr_period', 'hr_timesheet_sheet'],
+    "data": [
+        'views/hr_timesheet_sheet_view.xml',
+    ],
+    "installable": True
+}

--- a/hr_timesheet_sheet_period/models/__init__.py
+++ b/hr_timesheet_sheet_period/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# Copyright 2016 Serpent Consulting Services Pvt. Ltd.
+#   (<http://www.serpentcs.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import hr_timesheet_sheet

--- a/hr_timesheet_sheet_period/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_period/models/hr_timesheet_sheet.py
@@ -98,11 +98,13 @@ class HrTimesheetSheet(models.Model):
             if timesheet.hr_period_id:
                 if timesheet.date_from != timesheet.hr_period_id.date_start:
                     raise UserError(
-                        _("The Date From must match with that of the "
-                          "Payslip period '%s'.") % (
+                        _("The Date From of Timesheet must match with that of"
+                          " date start '%s' of the Payroll period '%s'.") % (
+                            timesheet.hr_period_id.date_start,
                             timesheet.hr_period_id.name))
                 if timesheet.date_to != timesheet.hr_period_id.date_stop:
                     raise UserError(
-                        _("The Date To must match with that of the "
-                          "Payslip period '%s'.") % (
+                        _("The Date To of Timesheet must match with that of"
+                          " date stop '%s' of the Payroll period '%s'.") % (
+                            timesheet.hr_period_id.date_stop,
                             timesheet.hr_period_id.name))

--- a/hr_timesheet_sheet_period/tests/__init__.py
+++ b/hr_timesheet_sheet_period/tests/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# Copyright 2016 Serpent Consulting Services Pvt. Ltd.
+#   (<http://www.serpentcs.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import test_hr_timesheet_sheet_period

--- a/hr_timesheet_sheet_period/tests/test_hr_timesheet_sheet_period.py
+++ b/hr_timesheet_sheet_period/tests/test_hr_timesheet_sheet_period.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# Copyright 2016 Serpent Consulting Services Pvt. Ltd.
+#   (<http://www.serpentcs.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openerp.tests import common
+from datetime import datetime
+from openerp.exceptions import ValidationError as UserError
+
+
+class TestHrTimesheetSheetPeriod(common.TransactionCase):
+
+    def setUp(self):
+        super(TestHrTimesheetSheetPeriod, self).setUp()
+        self.user_model = self.env["res.users"]
+        self.company_model = self.env['res.company']
+        self.timeheet_model = self.env['hr_timesheet_sheet.sheet']
+        self.fiscal_year_model = self.env['hr.fiscalyear']
+        self.hr_contract_model = self.env['hr.contract']
+        self.employee_model = self.env['hr.employee']
+
+        self.today_date = datetime.today().date()
+        self.date_start = datetime.today().strftime('%Y-01-01')
+        self.date_stop = datetime.today().strftime('%Y-12-31')
+        self.company = self.company_model.create({'name': 'Test Company'})
+        self.user = self.env.ref('base.user_root')
+
+    def create_fiscal_year(self):
+        vals = {
+            'company_id': self.company.id,
+            'date_start': self.date_start,
+            'date_stop': self.date_stop,
+            'schedule_pay': 'monthly',
+            'payment_day': '2',
+            'name': 'Test Fiscal Year 2017',
+        }
+
+        fiscal_year = self.fiscal_year_model.create(vals)
+
+        return fiscal_year
+
+    def create_hr_timesheet_sheet(self):
+        self.employee = self.employee_model.create({'name': 'Test Employee',
+                                                    'user_id': self.user.id})
+        timesheet_sheet = self.timeheet_model.\
+            create({'employee_id': self.employee.id})
+        return timesheet_sheet
+
+    def test_hr_timesheet_period(self):
+        fiscal_year = self.create_fiscal_year()
+        fiscal_year.create_periods()
+        fiscal_year.button_confirm()
+        hr_timesheet = self.create_hr_timesheet_sheet()
+
+        self.assertEqual(hr_timesheet.hr_period_id.date_start,
+                         hr_timesheet.date_from)
+        self.assertEqual(hr_timesheet.hr_period_id.date_stop,
+                         hr_timesheet.date_to)
+        self.assertEqual(self.today_date.month,
+                         hr_timesheet.hr_period_id.number)
+        with self.assertRaises(UserError):
+            hr_timesheet.date_to = '2015-12-31'
+
+    def test_period_from_employee_contract(self):
+        fiscal_year = self.create_fiscal_year()
+        fiscal_year.create_periods()
+        fiscal_year.button_confirm()
+        hr_timesheet = self.create_hr_timesheet_sheet()
+        salary_structure = self.env.ref('hr_payroll.structure_001')
+
+        contract_vals = {
+            'employee_id': self.employee.id,
+            'struct_id': salary_structure.id,
+            'schedule_pay': 'quarterly',
+            'name': 'Test Contract',
+            'wage': 20000
+        }
+
+        hr_contract = self.hr_contract_model.create(contract_vals)
+
+        self.assertEqual(hr_timesheet.hr_period_id.date_start,
+                         hr_timesheet.date_from)
+        self.assertEqual(hr_timesheet.hr_period_id.date_stop,
+                         hr_timesheet.date_to)
+        self.assertEqual(self.today_date.month,
+                         hr_timesheet.hr_period_id.number)
+        self.assertEqual(hr_contract.schedule_pay,
+                         hr_timesheet.hr_period_id.schedule_pay)
+        with self.assertRaises(UserError):
+            hr_timesheet.date_to = '2015-12-31'

--- a/hr_timesheet_sheet_period/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_sheet_period/views/hr_timesheet_sheet_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="hr_timesheet_sheet_form" model="ir.ui.view">
+            <field name="name">hr.timesheet.sheet.form</field>
+            <field name="model">hr_timesheet_sheet.sheet</field>
+            <field name="inherit_id"
+                   ref="hr_timesheet_sheet.hr_timesheet_sheet_form"/>
+            <field name="arch" type="xml">
+                <field name="name" position="before">
+                    <field name="hr_period_id"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_hr_timesheet_sheet_filter" model="ir.ui.view">
+            <field name="name">hr_timesheet_sheet.sheet.filter</field>
+            <field name="model">hr_timesheet_sheet.sheet</field>
+            <field name="inherit_id"
+                   ref="hr_timesheet_sheet.view_hr_timesheet_sheet_filter"/>
+            <field name="arch" type="xml">
+                <field name="date_from" position="after">
+                    <field name="hr_period_id"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
# **HR Timesheet Sheet based on Payroll Period**

This module allows creating timesheets with start and end dates matching with the
payroll period of the schedule pay that is specified in the contract of an 
employee or if not then will match the nearest payroll period.

## **Configuration**

Create first the Payroll Fiscal Years and Payroll
Periods from 'Human Resources > Configuration > Payroll'

## **Usage**

When the user goes to 'Human Resources > Time Tracking > My current
timesheet', the application will attempt to create a new timesheet using as
start and end dates the Pay Period corresponding to today's date.