### PR TITLE
[FIX] don't write account_name

### DIFF
--- a/hr_timesheet_improvement/__openerp__.py
+++ b/hr_timesheet_improvement/__openerp__.py
@@ -26,7 +26,10 @@
  'category': 'Human Resources',
  'depends': ['hr_timesheet_sheet'],
  'website': 'http://www.camptocamp.com',
- 'data': ['hr_timesheet_view.xml'],
+ 'data': [
+     'hr_timesheet_view.xml',
+     'views/templates.xml',
+ ],
  'js': [],
  'css': [],
  'qweb': [],

--- a/hr_timesheet_improvement/hr_timesheet.py
+++ b/hr_timesheet_improvement/hr_timesheet.py
@@ -47,4 +47,17 @@ class HrAnalyticTimesheet(models.Model):
                 [f for f in self._columns.keys() if f != 'account_name'],
                 trigger[2],
             )
+        store_specs = self.pool._store_function.get(self._name, [])
+        for store_spec in store_specs:
+            if store_spec[1] == 'sheet_id' and store_spec[3] is None:
+                store_specs.remove(store_spec)
+                store_specs.append(tuple(
+                    list(store_spec[:3]) +
+                    [
+                        self._columns['sheet_id']
+                        .store['hr.analytic.timesheet'][1]
+                    ] +
+                    list(store_spec[4:])
+                ))
+                break
         return super(HrAnalyticTimesheet, self)._register_hook(cr)

--- a/hr_timesheet_improvement/hr_timesheet.py
+++ b/hr_timesheet_improvement/hr_timesheet.py
@@ -34,3 +34,17 @@ class HrAnalyticTimesheet(models.Model):
 
     account_name = fields.Char(related='account_id.name',
                                store=True, readonly=True)
+
+    def _register_hook(self, cr):
+        """Patch recomputation of sheet_id to never recompute when
+        account_name changes"""
+        if self._columns['sheet_id'].store.get(
+                'hr.analytic.timesheet', [None, None, None]
+        )[1] is None:
+            trigger = self._columns['sheet_id'].store['hr.analytic.timesheet']
+            self._columns['sheet_id'].store['hr.analytic.timesheet'] = (
+                trigger[0],
+                [f for f in self._columns.keys() if f != 'account_name'],
+                trigger[2],
+            )
+        return super(HrAnalyticTimesheet, self)._register_hook(cr)

--- a/hr_timesheet_improvement/hr_timesheet.py
+++ b/hr_timesheet_improvement/hr_timesheet.py
@@ -44,7 +44,7 @@ class HrAnalyticTimesheet(models.Model):
             trigger = self._columns['sheet_id'].store['hr.analytic.timesheet']
             self._columns['sheet_id'].store['hr.analytic.timesheet'] = (
                 trigger[0],
-                [f for f in self._columns.keys() if f != 'account_name'],
+                tuple(f for f in self._columns.keys() if f != 'account_name'),
                 trigger[2],
             )
         store_specs = self.pool._store_function.get(self._name, [])

--- a/hr_timesheet_improvement/static/src/js/hr_timesheet_improvement.js
+++ b/hr_timesheet_improvement/static/src/js/hr_timesheet_improvement.js
@@ -8,8 +8,9 @@ openerp.hr_timesheet_improvement = function(instance)
         ignore_fields: function()
         {
             var result = this._super.apply(this, arguments);
-            // we don't want to try to write on the account
+            // we don't want to try to write on the related fields
             result.push('account_name');
+            result.push('date_aal');
             return result
         },
     });

--- a/hr_timesheet_improvement/static/src/js/hr_timesheet_improvement.js
+++ b/hr_timesheet_improvement/static/src/js/hr_timesheet_improvement.js
@@ -1,0 +1,16 @@
+//-*- coding: utf-8 -*-
+//© 2017 Therp BV <http://therp.nl>
+//License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+openerp.hr_timesheet_improvement = function(instance)
+{
+    instance.hr_timesheet_sheet.WeeklyTimesheet.include({
+        ignore_fields: function()
+        {
+            var result = this._super.apply(this, arguments);
+            // we don't want to try to write on the account
+            result.push('account_name');
+            return result
+        },
+    });
+}

--- a/hr_timesheet_improvement/views/templates.xml
+++ b/hr_timesheet_improvement/views/templates.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <template id="assets_backend" name="hr_timesheet_improvement assets" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/hr_timesheet_improvement/static/src/js/hr_timesheet_improvement.js"></script>
+            </xpath>
+        </template>
+    </data>
+</openerp>


### PR DESCRIPTION
the issue here is that the second `write` on a timesheet will have the `account_name` field filled in the timesheet lines. This would trigger a write on the account involved, and then it either breaks due to permissions or due to recomputation