### PR TITLE
[9.0][hr_timesheet_activity_begin_end] migration to v9

### DIFF
--- a/hr_timesheet_activity_begin_end/__openerp__.py
+++ b/hr_timesheet_activity_begin_end/__openerp__.py
@@ -1,28 +1,11 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Authors: Guewen Baconnier, Fabien Moret
-#    Copyright 2015 Camptocamp SA
-#    Copyright 2017 Martronic SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# © 2015 Camptocamp SA (author: Guewen Baconnier)
+# © 2017 Martronic SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {'name': 'Timesheet Activities - Begin/End Hours',
  'version': '9.0.1.0.0',
- 'author': 'Martronic SA,Camptocamp,Odoo Community Association (OCA)',
+ 'author': 'Camptocamp,Martronic SA,Odoo Community Association (OCA)',
  'license': 'AGPL-3',
  'category': 'Human Resources',
  'depends': ['hr_timesheet_sheet',

--- a/hr_timesheet_activity_begin_end/__openerp__.py
+++ b/hr_timesheet_activity_begin_end/__openerp__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 #
-#    Authors: Guewen Baconnier
+#    Authors: Guewen Baconnier, Fabien Moret
 #    Copyright 2015 Camptocamp SA
+#    Copyright 2017 Martronic SA
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -20,8 +21,8 @@
 #
 
 {'name': 'Timesheet Activities - Begin/End Hours',
- 'version': '8.0.1.0.0',
- 'author': 'Camptocamp,Odoo Community Association (OCA)',
+ 'version': '9.0.1.0.0',
+ 'author': 'Martronic SA,Camptocamp,Odoo Community Association (OCA)',
  'license': 'AGPL-3',
  'category': 'Human Resources',
  'depends': ['hr_timesheet_sheet',
@@ -31,6 +32,6 @@
           'views/hr_timesheet_sheet.xml',
           ],
  'test': [],
- 'installable': False,
+ 'installable': True,
  'auto_install': False,
  }

--- a/hr_timesheet_activity_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_activity_begin_end/models/account_analytic_line.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Authors: Guewen Baconnier
-#    Copyright 2015 Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# © 2015 Camptocamp SA (author: Guewen Baconnier)
+# © 2017 Martronic SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from __future__ import division
 

--- a/hr_timesheet_activity_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_activity_begin_end/models/account_analytic_line.py
@@ -84,39 +84,6 @@ class AccountAnalyticLine(models.Model):
                                   )])
             raise exceptions.ValidationError(message)
 
-
-class HrAnalyticTimesheet(models.Model):
-    _inherit = 'hr.analytic.timesheet'
-
-    _order = "id desc"
-    _order = ("aal_date DESC, aal_time_start DESC,"
-              "aal_time_stop DESC, aal_account_name ASC")
-
-    aal_date = fields.Date(
-        string='Analytic Line Date',
-        related='line_id.date',
-        store=True,
-        readonly=True,
-    )
-    aal_time_start = fields.Float(
-        string='Analytic Line Begin Hour',
-        related='line_id.time_start',
-        store=True,
-        readonly=True,
-    )
-    aal_time_stop = fields.Float(
-        string='Analytic Line Begin Hour',
-        related='line_id.time_stop',
-        store=True,
-        readonly=True,
-    )
-    aal_account_name = fields.Char(
-        string='Analytic Account Name',
-        related='account_id.name',
-        store=True,
-        readonly=True,
-    )
-
     @api.onchange('time_start', 'time_stop')
     def onchange_hours_start_stop(self):
         start = timedelta(hours=self.time_start)
@@ -124,3 +91,4 @@ class HrAnalyticTimesheet(models.Model):
         if stop < start:
             return
         self.unit_amount = (stop - start).seconds / 3600
+

--- a/hr_timesheet_activity_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_activity_begin_end/models/account_analytic_line.py
@@ -92,4 +92,3 @@ class AccountAnalyticLine(models.Model):
         if stop < start:
             return
         self.unit_amount = (stop - start).seconds / 3600
-

--- a/hr_timesheet_activity_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_activity_begin_end/models/account_analytic_line.py
@@ -44,9 +44,10 @@ class AccountAnalyticLine(models.Model):
     time_start = fields.Float(string='Begin Hour')
     time_stop = fields.Float(string='End Hour')
 
-    @api.one
+    @api.multi
     @api.constrains('time_start', 'time_stop', 'unit_amount')
     def _check_time_start_stop(self):
+        self.ensure_one()
         start = timedelta(hours=self.time_start)
         stop = timedelta(hours=self.time_stop)
         if stop < start:

--- a/hr_timesheet_activity_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_activity_begin_end/models/account_analytic_line.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2015 Camptocamp SA (author: Guewen Baconnier)
-# © 2017 Martronic SA
+# Copyright 2015 Camptocamp SA (author: Guewen Baconnier)
+# Copyright 2017 Martronic SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from __future__ import division

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -30,7 +30,7 @@ class TestBeginEnd(common.TransactionCase):
         self.timesheet_line_model = self.env['account.analytic.line']
         self.consultant = self.env.ref('product.product_product_1')
         self.analytic = self.env.ref('analytic.analytic_administratif')
-        self.expense = self.env.ref('account.a_expense')
+        self.expense = self.env.ref('a_expense')
         self.hour = self.env.ref('product.product_uom_hour')
         self.user = self.env.ref('base.user_root')
         self.base_line = {

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -65,7 +65,7 @@ class TestBeginEnd(common.TransactionCase):
             'time_stop': 10.,
         })
         line.onchange_hours_start_stop()
-        self.assertEquals(line.unit_amount, 2)
+        self.assertEquals(line.unit_amount, False)
 
     def test_check_begin_before_end(self):
         message_re = (r"The beginning hour \(\d\d:\d\d\) must precede "
@@ -79,7 +79,8 @@ class TestBeginEnd(common.TransactionCase):
             self.timesheet_line_model.create(line)
 
     def test_float_time_convert(self):
-        message_re = (r"Text error message in case of > 59.5 secs remains.")
+        message_re = (r"The beginning hour \(\d\d:\d\d\) must precede "
+                      r"the ending hour \(\d\d:00)\.")
         line = self.base_line.copy()
         line.update({
             'time_start': 12.,

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -29,7 +29,7 @@ class TestBeginEnd(common.TransactionCase):
         super(TestBeginEnd, self).setUp()
         self.timesheet_line_model = self.env['account.analytic.line']
         self.consultant = self.env.ref('product.product_product_1')
-        self.analytic = self.env.ref('account.analytic_administratif')
+        self.analytic = self.env.ref('analytic.analytic_administratif')
         self.expense = self.env.ref('account.a_expense')
         self.hour = self.env.ref('product.product_uom_hour')
         self.user = self.env.ref('base.user_root')

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -28,7 +28,7 @@ class TestBeginEnd(common.TransactionCase):
     def setUp(self):
         super(TestBeginEnd, self).setUp()
         self.timesheet_line_model = self.env['account.analytic.line']
-        self.consultant = self.env.ref('product.product_product_consultant')
+        self.consultant = self.env.ref('product.product_product_1')
         self.analytic = self.env.ref('account.analytic_administratif')
         self.expense = self.env.ref('account.a_expense')
         self.hour = self.env.ref('product.product_uom_hour')

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -27,7 +27,7 @@ class TestBeginEnd(common.TransactionCase):
 
     def setUp(self):
         super(TestBeginEnd, self).setUp()
-        self.timesheet_line_model = self.env['hr.analytic.timesheet']
+        self.timesheet_line_model = self.env['account.analytic.line']
         self.consultant = self.env.ref('product.product_product_consultant')
         self.analytic = self.env.ref('account.analytic_administratif')
         self.expense = self.env.ref('account.a_expense')

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -46,7 +46,6 @@ class TestBeginEnd(common.TransactionCase):
             'account_id': self.analytic.id,
             'amount': -60.,
             'general_account_id': self.expense.id,
-            'journal_id': self.journal.id,
         }
 
     def test_onchange(self):

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -30,7 +30,9 @@ class TestBeginEnd(common.TransactionCase):
         self.timesheet_line_model = self.env['account.analytic.line']
         self.consultant = self.env.ref('product.product_product_1')
         self.analytic = self.env.ref('analytic.analytic_administratif')
-        self.expense = self.env['account.account'].search([('user_type_id', '=', self.env.ref('account.data_account_type_expenses').id)], limit=1)
+        expenses_id = self.env.ref('account.data_account_type_expenses').id
+        self.expense = self.env['account.account'].search(
+            [('user_type_id', '=', expenses_id)], limit=1)
         self.hour = self.env.ref('product.product_uom_hour')
         self.user = self.env.ref('base.user_root')
         self.base_line = {

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -31,7 +31,6 @@ class TestBeginEnd(common.TransactionCase):
         self.consultant = self.env.ref('product.product_product_consultant')
         self.analytic = self.env.ref('account.analytic_administratif')
         self.expense = self.env.ref('account.a_expense')
-        self.journal = self.env.ref('hr_timesheet.analytic_journal')
         self.hour = self.env.ref('product.product_uom_hour')
         self.user = self.env.ref('base.user_root')
         self.base_line = {

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -79,6 +79,7 @@ class TestBeginEnd(common.TransactionCase):
             self.timesheet_line_model.create(line)
 
     def test_float_time_convert(self):
+        message_re = (r"Text error message in case of > 59.5 secs remains.")
         line = self.base_line.copy()
         line.update({
             'time_start': 12.,

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -80,7 +80,7 @@ class TestBeginEnd(common.TransactionCase):
 
     def test_float_time_convert(self):
         message_re = (r"The beginning hour \(\d\d:\d\d\) must precede "
-                      r"the ending hour \(\d\d:00)\.")
+                      r"the ending hour \(\d\d:00\)\.")
         line = self.base_line.copy()
         line.update({
             'time_start': 12.,

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -58,6 +58,15 @@ class TestBeginEnd(common.TransactionCase):
         line.onchange_hours_start_stop()
         self.assertEquals(line.unit_amount, 2)
 
+    def test_onchange_begin_before_end(self):
+        line = self.timesheet_line_model.new({
+            'name': 'test',
+            'time_start': 12.,
+            'time_stop': 10.,
+        })
+        line.onchange_hours_start_stop()
+        self.assertEquals(line.unit_amount, 2)
+
     def test_check_begin_before_end(self):
         message_re = (r"The beginning hour \(\d\d:\d\d\) must precede "
                       r"the ending hour \(\d\d:\d\d\)\.")
@@ -65,6 +74,15 @@ class TestBeginEnd(common.TransactionCase):
         line.update({
             'time_start': 12.,
             'time_stop': 10.,
+        })
+        with self.assertRaisesRegexp(exceptions.ValidationError, message_re):
+            self.timesheet_line_model.create(line)
+
+    def test_float_time_convert(self):
+        line = self.base_line.copy()
+        line.update({
+            'time_start': 12.,
+            'time_stop': 10.995,
         })
         with self.assertRaisesRegexp(exceptions.ValidationError, message_re):
             self.timesheet_line_model.create(line)

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -30,7 +30,7 @@ class TestBeginEnd(common.TransactionCase):
         self.timesheet_line_model = self.env['account.analytic.line']
         self.consultant = self.env.ref('product.product_product_1')
         self.analytic = self.env.ref('analytic.analytic_administratif')
-        self.expense = self.env.ref('a_expense')
+        self.expense = self.env['account.account'].search([('user_type_id', '=', self.env.ref('account.data_account_type_expenses').id)], limit=1)
         self.hour = self.env.ref('product.product_uom_hour')
         self.user = self.env.ref('base.user_root')
         self.base_line = {

--- a/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
+++ b/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-  <data>
     <record id="hr_timesheet_line_tree" model="ir.ui.view">
       <field name="name">hr.analytic.timesheet.tree</field>
       <field name="model">account.analytic.line</field>
@@ -24,6 +23,4 @@
         </xpath>
       </field>
     </record>
-
-  </data>
 </openerp>

--- a/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
+++ b/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
@@ -3,7 +3,7 @@
   <data>
     <record id="hr_timesheet_line_tree" model="ir.ui.view">
       <field name="name">hr.analytic.timesheet.tree</field>
-      <field name="model">hr.analytic.timesheet</field>
+      <field name="model">account.analytic.line</field>
       <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
       <field name="arch" type="xml">
         <field name="unit_amount" position="before">
@@ -15,7 +15,7 @@
 
     <record id="hr_timesheet_line_form" model="ir.ui.view">
       <field name="name">hr.analytic.timesheet.form</field>
-      <field name="model">hr.analytic.timesheet</field>
+      <field name="model">account.analytic.line</field>
       <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form"/>
       <field name="arch" type="xml">
         <xpath expr="//field[@name='unit_amount']/.."  position="before">

--- a/hr_timesheet_activity_begin_end/views/hr_timesheet_sheet.xml
+++ b/hr_timesheet_activity_begin_end/views/hr_timesheet_sheet.xml
@@ -10,7 +10,7 @@
           <field name="time_start" widget="float_time"/>
           <field name="time_stop" widget="float_time"/>
         </xpath>
-        <xpath expr="//field[@name='timesheet_ids']/form/field[@name='unit_amount']" position="before">
+        <xpath expr="//field[@name='timesheet_ids']/form/group/field[@name='unit_amount']" position="before">
           <field name="time_start" widget="float_time"/>
           <field name="time_stop" widget="float_time"/>
         </xpath>


### PR DESCRIPTION
model hr.analytic.timesheet has been removed so we have moved functions to account.analytic.line and changed model of related views.