### PR TITLE
[FIX][crm_timesheet] Do not restrict project

### DIFF
--- a/crm_timesheet/__manifest__.py
+++ b/crm_timesheet/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': "CRM Timesheet",
     'category': 'Customer Relationship Management',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'depends': [
         'crm',
         'hr_timesheet'

--- a/crm_timesheet/models/account_analytic_line.py
+++ b/crm_timesheet/models/account_analytic_line.py
@@ -21,13 +21,8 @@ class AccountAnalyticLine(models.Model):
             ])
             if len(projects) == 1:
                 self.project_id = projects
-            return {
-                'domain': {
-                    'project_id': [
-                        ('analytic_account_id', '=', self.account_id.id),
-                    ],
-                },
-            }
+            elif not self.project_id < projects:
+                self.project_id = False
 
     @api.onchange('project_id')
     def _onchange_project_id(self):

--- a/crm_timesheet/tests/__init__.py
+++ b/crm_timesheet/tests/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_account_analytic_line

--- a/crm_timesheet/tests/test_account_analytic_line.py
+++ b/crm_timesheet/tests/test_account_analytic_line.py
@@ -69,6 +69,8 @@ class AccountAnalyticLineCase(SavepointCase):
         line._onchange_project_id()
         self.assertEqual(line.account_id, self.account2)
         line.project_id = self.project11
+        line._onchange_project_id()
         self.assertEqual(line.account_id, self.account1)
         line.project_id = self.project0
+        line._onchange_project_id()
         self.assertFalse(line.account_id)

--- a/crm_timesheet/tests/test_account_analytic_line.py
+++ b/crm_timesheet/tests/test_account_analytic_line.py
@@ -18,9 +18,6 @@ class AccountAnalyticLineCase(SavepointCase):
         cls.account2 = Account.create({
             "name": "Account 2",
         })
-        cls.project0 = Project.create({
-            "name": "Project 0",
-        })
         cls.project11 = Project.create({
             "name": "Project 1.1",
             "analytic_account_id": cls.account1.id,
@@ -71,6 +68,3 @@ class AccountAnalyticLineCase(SavepointCase):
         line.project_id = self.project11
         line._onchange_project_id()
         self.assertEqual(line.account_id, self.account1)
-        line.project_id = self.project0
-        line._onchange_project_id()
-        self.assertFalse(line.account_id)

--- a/crm_timesheet/tests/test_account_analytic_line.py
+++ b/crm_timesheet/tests/test_account_analytic_line.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp.tests.common import SavepointCase
+
+
+class AccountAnalyticLineCase(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(AccountAnalyticLineCase, cls).setUpClass()
+        Account = cls.env["account.analytic.account"]
+        Project = cls.env["project.project"]
+        cls.Line = cls.env["account.analytic.line"]
+        cls.account1 = Account.create({
+            "name": "Account 1",
+        })
+        cls.account2 = Account.create({
+            "name": "Account 2",
+        })
+        cls.project0 = Project.create({
+            "name": "Project 0",
+        })
+        cls.project11 = Project.create({
+            "name": "Project 1.1",
+            "analytic_account_id": cls.account1.id,
+        })
+        cls.project12 = Project.create({
+            "name": "Project 1.2",
+            "analytic_account_id": cls.account1.id,
+        })
+        cls.project21 = Project.create({
+            "name": "Project 2.1",
+            "analytic_account_id": cls.account2.id,
+        })
+
+    def test_onchange_account_multi_project(self):
+        """Changing the account leaves empty project."""
+        line = self.Line.new({
+            "account_id": self.account1,
+        })
+        line._onchange_account_id()
+        self.assertFalse(line.project_id)
+
+    def test_onchange_account_single_project(self):
+        """Changing account sets project."""
+        line = self.Line.new({
+            "account_id": self.account2,
+        })
+        line._onchange_account_id()
+        self.assertEqual(line.project_id, self.project21)
+
+    def test_onchange_account_wrong_project(self):
+        """Changing account unsets project."""
+        line = self.Line.new({
+            "project_id": self.project21,
+        })
+        line._onchange_project_id()
+        self.assertEqual(line.account_id, self.account2)
+        line.account_id = self.account1
+        line._onchange_account_id()
+        self.assertFalse(line.project_id)
+
+    def test_onchange_project(self):
+        """Changing the project changes the account."""
+        line = self.Line.new({
+            "project_id": self.project21,
+        })
+        line._onchange_project_id()
+        self.assertEqual(line.account_id, self.account2)
+        line.project_id = self.project11
+        self.assertEqual(line.account_id, self.account1)
+        line.project_id = self.project0
+        self.assertFalse(line.account_id)

--- a/crm_timesheet/views/hr_timesheet_view.xml
+++ b/crm_timesheet/views/hr_timesheet_view.xml
@@ -9,9 +9,6 @@
         <field name="project_id" position="attributes">
             <attribute name="required">not context.get('from_lead')</attribute>
         </field>
-        <field name="project_id" position="after">
-            <field name="account_id" invisible="not context.get('from_lead')"/>
-        </field>
         <field name="task_id" position="after">
             <field name="lead_id" invisible="context.get('from_lead')"/>
         </field>


### PR DESCRIPTION
This addon assumed one will always fill the analytic account before the project, but current behavior does not let you choose a project outside current analytic account, which in practice means you can never change the project if `analytic_account_id` field is hidden (as it happens in other addons such as `project_issue_timesheet_time_control`).

Now, if you choose a project it will fill the analytic account, and also the other way around, so why bother about the domains?

@Tecnativa