### PR TITLE
[IMP] crm_timesheet: Use projects

### DIFF
--- a/crm_timesheet/__manifest__.py
+++ b/crm_timesheet/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': "CRM Timesheet",
     'category': 'Customer Relationship Management',
-    'version': '10.0.1.1.1',
+    'version': '10.0.2.0.0',
     'depends': [
         'crm',
         'hr_timesheet'

--- a/crm_timesheet/models/account_analytic_line.py
+++ b/crm_timesheet/models/account_analytic_line.py
@@ -13,18 +13,7 @@ class AccountAnalyticLine(models.Model):
     lead_id = fields.Many2one(comodel_name='crm.lead',
                               string='Lead/Opportunity')
 
-    @api.onchange('account_id')
-    def _onchange_account_id(self):
-        if self.account_id:
-            projects = self.env['project.project'].search([
-                ('analytic_account_id', '=', self.account_id.id),
-            ])
-            if len(projects) == 1:
-                self.project_id = projects
-            elif not self.project_id < projects:
-                self.project_id = False
-
-    @api.onchange('project_id')
-    def _onchange_project_id(self):
-        if self.project_id:
-            self.account_id = self.project_id.analytic_account_id
+    @api.onchange('lead_id')
+    def _onchange_lead_id(self):
+        if self.lead_id.project_id:
+            self.project_id = self.lead_id.project_id.id

--- a/crm_timesheet/models/crm_lead.py
+++ b/crm_timesheet/models/crm_lead.py
@@ -10,8 +10,8 @@ from odoo import fields, models
 class CrmLead(models.Model):
     _inherit = 'crm.lead'
 
-    analytic_account_id = fields.Many2one(
-        comodel_name='account.analytic.account', string="Analytic account",
+    project_id = fields.Many2one(
+        comodel_name='project.project', string="Project",
     )
     timesheet_ids = fields.One2many(
         comodel_name='account.analytic.line', inverse_name='lead_id',

--- a/crm_timesheet/tests/test_account_analytic_line.py
+++ b/crm_timesheet/tests/test_account_analytic_line.py
@@ -13,58 +13,21 @@ class AccountAnalyticLineCase(SavepointCase):
         Project = cls.env["project.project"]
         cls.Line = cls.env["account.analytic.line"]
         cls.account1 = Account.create({
-            "name": "Account 1",
+            "name": "Test Account 1",
         })
-        cls.account2 = Account.create({
-            "name": "Account 2",
-        })
-        cls.project11 = Project.create({
-            "name": "Project 1.1",
+        cls.project1 = Project.create({
+            "name": "Test Project 1",
             "analytic_account_id": cls.account1.id,
         })
-        cls.project12 = Project.create({
-            "name": "Project 1.2",
-            "analytic_account_id": cls.account1.id,
-        })
-        cls.project21 = Project.create({
-            "name": "Project 2.1",
-            "analytic_account_id": cls.account2.id,
+        cls.lead = cls.env['crm.lead'].create({
+            'name': 'Test lead',
+            'project_id': cls.project1.id,
         })
 
-    def test_onchange_account_multi_project(self):
-        """Changing the account leaves empty project."""
+    def test_onchange_lead(self):
+        """Changing the lead changes the associated project."""
         line = self.Line.new({
-            "account_id": self.account1,
+            "lead_id": self.lead.id,
         })
-        line._onchange_account_id()
-        self.assertFalse(line.project_id)
-
-    def test_onchange_account_single_project(self):
-        """Changing account sets project."""
-        line = self.Line.new({
-            "account_id": self.account2,
-        })
-        line._onchange_account_id()
-        self.assertEqual(line.project_id, self.project21)
-
-    def test_onchange_account_wrong_project(self):
-        """Changing account unsets project."""
-        line = self.Line.new({
-            "project_id": self.project21,
-        })
-        line._onchange_project_id()
-        self.assertEqual(line.account_id, self.account2)
-        line.account_id = self.account1
-        line._onchange_account_id()
-        self.assertFalse(line.project_id)
-
-    def test_onchange_project(self):
-        """Changing the project changes the account."""
-        line = self.Line.new({
-            "project_id": self.project21,
-        })
-        line._onchange_project_id()
-        self.assertEqual(line.account_id, self.account2)
-        line.project_id = self.project11
-        line._onchange_project_id()
-        self.assertEqual(line.account_id, self.account1)
+        line._onchange_lead_id()
+        self.assertEqual(line.project_id, self.project1)

--- a/crm_timesheet/views/crm_lead_view.xml
+++ b/crm_timesheet/views/crm_lead_view.xml
@@ -7,12 +7,12 @@
     <field name="inherit_id" ref="crm.crm_case_form_view_leads"/>
     <field name="arch" type="xml">
         <field name="user_id" position="after">
-            <field name="analytic_account_id" />
+            <field name="project_id" />
         </field>
         <page name="extra" position="after">
             <page string="Timesheet">
                 <field name="timesheet_ids"
-                    context="{'default_account_id': analytic_account_id, 'default_user_id': uid, 'tree_view_ref': 'hr_timesheet.hr_timesheet_line_tree', 'from_lead': True}"/>
+                    context="{'default_project_id': project_id, 'default_user_id': uid, 'tree_view_ref': 'hr_timesheet.hr_timesheet_line_tree', 'from_lead': True}"/>
             </page>
         </page>
     </field>
@@ -24,12 +24,12 @@
     <field name="inherit_id" ref="crm.crm_case_form_view_oppor"/>
     <field name="arch" type="xml">
         <field name="user_id" position="after">
-            <field name="analytic_account_id" />
+            <field name="project_id" />
         </field>
         <page name="lead" position="after">
             <page string="Timesheet">
                 <field name="timesheet_ids"
-                    context="{'default_account_id': analytic_account_id, 'default_user_id': uid, 'tree_view_ref': 'hr_timesheet.hr_timesheet_line_tree', 'from_lead': True}" />
+                    context="{'default_project_id': project_id, 'default_user_id': uid, 'tree_view_ref': 'hr_timesheet.hr_timesheet_line_tree', 'from_lead': True}" />
             </page>
         </page>
     </field>

--- a/crm_timesheet/views/hr_timesheet_view.xml
+++ b/crm_timesheet/views/hr_timesheet_view.xml
@@ -6,9 +6,6 @@
     <field name="model">account.analytic.line</field>
     <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
     <field name="arch" type="xml">
-        <field name="project_id" position="attributes">
-            <attribute name="required">not context.get('from_lead')</attribute>
-        </field>
         <field name="task_id" position="after">
             <field name="lead_id" invisible="context.get('from_lead')"/>
         </field>


### PR DESCRIPTION
As now hr_timesheet bases all their functionality on projects, there's no sense to keep the old behavior linking crm.lead times to analytic account instead of projects, so I have changed this, making easier the associated logic (which, in the other hand, was not fully correct previously).

@Tecnativa