### PR TITLE
[RFR] make timesheet adoptions overridable

### DIFF
--- a/hr_timesheet_no_closed_project_task/static/src/js/timesheet.js
+++ b/hr_timesheet_no_closed_project_task/static/src/js/timesheet.js
@@ -1,22 +1,16 @@
 /* © 2015 ACSONE SA/NV (http://acsone.eu)
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
-openerp.hr_timesheet_no_closed_project_task = function(instance) { 
+openerp.hr_timesheet_no_closed_project_task = function(instance) {
 
     var module = instance.hr_timesheet_sheet
 
     module.WeeklyTimesheet = module.WeeklyTimesheet.extend({
-        
         init_add_account: function() {
             var self = this
             this._super.apply(this, arguments);
-            self.account_m2o.node.attrs.domain.push(['project_ids.state', 'not in', ['close', 'cancelled']]);
-            self.task_m2o.node.attrs.domain.push(['stage_id.closed', '=', false]);
+            self.account_m2o.node.attrs.domain.add([['project_ids.state', 'not in', ['close', 'cancelled']]]);
+            self.task_m2o.node.attrs.domain.add([['stage_id.closed', '=', false]]);
         },
-        onchange_account_id: function() {
-            var self = this
-            this._super.apply(this, arguments);
-            self.task_m2o.node.attrs.domain.push(['stage_id.closed', '=', false]);
-        }
     });
 };

--- a/hr_timesheet_task/README.rst
+++ b/hr_timesheet_task/README.rst
@@ -1,0 +1,64 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+==================
+Task in time sheet
+==================
+
+This module was written to allow you to record time on tasks via timesheets.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+    :alt: Try me on Runbot
+    :target: https://runbot.odoo-community.org/runbot/117/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/hr_timesheet_task/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Adrien Peiffer <adrien.peiffer@acsone.eu>
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+* Anthony Muschang <anthony.muschang@acsone.eu>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Holger Brunn <hbrunn@therp.nl>
+* Joël Grand-Guillaume <joel.grandguillaume@camptocamp.com>
+* Laetitia Gangloff <laetitia.gangloff@acsone.eu>
+* Laurent Mignon <laurent.mignon@acsone.eu>
+* Olivier Laurent <olivier.laurent@acsone.eu>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Stéphane Bidoul <stephane.bidoul@acsone.eu>
+* Nicolas Bessi <nicolas.bessi@camptocamp.com>
+* Yannick Vaucher <yannick.vaucher@camptocamp.com>
+
+Do not contact contributors directly about help with questions or problems concerning this addon, but use the `community mailing list <mailto:community@mail.odoo.com>`_ or the `appropriate specialized mailinglist <https://odoo-community.org/groups>`_ for help, and the bug tracker linked in `Bug Tracker`_ above for technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.
+

--- a/hr_timesheet_task/__openerp__.py
+++ b/hr_timesheet_task/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Author: Nicolas Bessi
@@ -24,8 +24,6 @@
  'maintainer': 'Camptocamp - Acsone SA/NV',
  'category': 'Human Resources',
  'depends': ['timesheet_task', 'hr_timesheet_sheet'],
- 'description': """Replace project.task.work items linked to task
-                   with hr.analytic.timesheet""",
  'website': 'http://www.camptocamp.com',
  'data': ['hr_timesheet_sheet_view.xml',
           'hr_analytic_timesheet_view.xml',
@@ -39,5 +37,3 @@
  'license': 'AGPL-3',
  'application': True,
  }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/hr_timesheet_task/static/src/js/timesheet.js
+++ b/hr_timesheet_task/static/src/js/timesheet.js
@@ -58,7 +58,12 @@ openerp.hr_timesheet_task = function(instance) {
             });
         },
         initialize_content_group: function() {
-            var self = this;
+            var
+            self = this,
+            existing_groups = _.chain(this.get('sheets'))
+                .groupBy(self.proxy('initialize_content_group_by'))
+                .keys();
+
             this.accounts = _.chain(this.accounts)
             .map(function(account)
             {
@@ -66,6 +71,10 @@ openerp.hr_timesheet_task = function(instance) {
                 .map(function(day) { return day.lines; })
                 .flatten(true)
                 .groupBy(self.proxy('initialize_content_group_by'))
+                .filter(function(records, group) {
+                    return !existing_groups.intersection([group]).isEmpty()
+                        .value();
+                })
                 .map(_.bind(
                     self.initialize_content_group_clone_account,
                     self, account

--- a/hr_timesheet_task/static/src/js/timesheet.js
+++ b/hr_timesheet_task/static/src/js/timesheet.js
@@ -196,7 +196,7 @@ openerp.hr_timesheet_task = function(instance) {
             // operations without a task id
             if(
                 arg1 && arg1.sheets && arg1.sheets.length && this.task_m2o &&
-                !this.setting
+                !this.setting && !this.querying
             )
             {
                 // the new record is the last one

--- a/hr_timesheet_task/static/src/js/timesheet.js
+++ b/hr_timesheet_task/static/src/js/timesheet.js
@@ -194,15 +194,17 @@ openerp.hr_timesheet_task = function(instance) {
         set: function(arg1, arg2, arg3) {
             // this is called by the click handler, we intercept setting
             // operations without a task id
-            var self = this;
-            if(arg1 && arg1.sheets && arg1.sheets.length && this.task_m2o)
+            if(
+                arg1 && arg1.sheets && arg1.sheets.length && this.task_m2o &&
+                !this.setting
+            )
             {
                 // the new record is the last one
                 var record = arg1.sheets[arg1.sheets.length - 1];
                 // this happens when adding a row via the ui
-                if(!record.task_id && self.task_m2o.get_value())
+                if(!record.task_id && this.task_m2o.get_value())
                 {
-                    record.task_id = self.task_m2o.get_value();
+                    record.task_id = this.task_m2o.get_value();
                 }
             }
             return this._super.apply(this, arguments);

--- a/hr_timesheet_task/static/src/js/timesheet.js
+++ b/hr_timesheet_task/static/src/js/timesheet.js
@@ -132,7 +132,10 @@ openerp.hr_timesheet_task = function(instance) {
             return result;
         },
         initialize_content_group_by: function(record) {
-            return _.str.sprintf('%s-%s', record.account_id, record.task_id);
+            return _.str.sprintf(
+                '%s-%s', this._m2o_id(record.account_id),
+                this._m2o_id(record.task_id)
+            );
         },
         _m2o_id: function(val) {
             // the || false is necessary because this can also be `undefined`

--- a/hr_timesheet_task/static/src/xml/timesheet.xml
+++ b/hr_timesheet_task/static/src/xml/timesheet.xml
@@ -2,34 +2,31 @@
 
 <templates>
     <t t-extend="hr_timesheet_sheet.WeeklyTimesheet">
-	   
-       <!-- Add a task column -->
-       <t t-jquery="th.oe_timesheet_first_col" t-operation="after">
+        <t t-jquery="tr[t-foreach='widget.accounts']">
+            jQuery(this).children().wrapAll('<t t-if="widget.task_names" />')
+        </t>
+        <!-- Add a task column -->
+        <t t-jquery="th.oe_timesheet_first_col" t-operation="after">
             <th class="oe_timesheet_task_col">Task</th>
         </t>
-
-        <!-- Replace all line created with the foreach to take account of task -->
-        <t t-jquery="tr:not([class]):nth-child(n+2)" t-operation="replace">
-            <tr t-foreach="widget.accounts" t-as="account">
-                <td class="oe_timesheet_weekly_account"><a href="javascript:void(0)" t-att-data-id="JSON.stringify(account.account)"><t t-esc="widget.account_names[account.account]"/></a></td>
-                <td class="oe_timesheet_weekly_task"><a href="javascript:void(0)" t-att-data-task-id="JSON.stringify(account.task)"><t t-esc="widget.task_names[account.task]" /></a></td>
-                <t t-set="day_count" t-value="0"/>
-                <t t-foreach="account.days" t-as="day">
-                    <td t-att-class="(Date.compare(day.day, Date.today()) === 0 ? 'oe_timesheet_weekly_today' : '')">
-                        <input t-if="!widget.get('effective_readonly')" class="oe_timesheet_weekly_input" 
-                            t-att-data-account-task="account.account_task" t-att-data-day-count="day_count" type="text"/>
-                        <span t-if="widget.get('effective_readonly')" class="oe_timesheet_weekly_box" 
-                            t-att-data-account-task="account.account_task" t-att-data-day-count="day_count"/>
-                        <t t-set="day_count" t-value="day_count + 1"/>
-                    </td>
-                </t>
-                <td t-att-data-account-task-total="account.account_task" class="oe_timesheet_total"> </td>
-            </tr>
+        <!-- add our table cells and data attributes -->
+        <t t-jquery="td.oe_timesheet_weekly_account" t-operation="after">
+            <td class="oe_timesheet_weekly_task">
+                <a href="javascript:void(0)" t-att-data-task-id="JSON.stringify(account.task_id)"><t t-esc="widget.task_names[account.task_id]" /></a>
+            </td>
         </t>
-
-        <!-- Add line in the last tr before the first element -->
-        <t t-jquery="tr.oe_timesheet_total > td:first-child" t-operation="after">
-            <td> </td>
+        <t t-jquery="td[t-att-data-account-total]">
+            jQuery(this).attr('t-att-data-task', 'account.task_id || 0');
+        </t>
+        <t t-jquery="input.oe_timesheet_weekly_input">
+            jQuery(this).attr('t-att-data-task', 'account.task_id || 0');
+        </t>
+        <t t-jquery="input + span.oe_timesheet_weekly_box">
+            jQuery(this).attr('t-att-data-task', 'account.task_id || 0');
+        </t>
+        <!-- Add cell in the last tr before the first element -->
+        <t t-jquery="tr.oe_timesheet_total > td:first-child">
+            jQuery(this).attr('colspan', 2);
         </t>
     </t>
 </templates>


### PR DESCRIPTION
The original code basically is a copy of hr_timesheet_sheet's js and xml code with the necessary changes. This combines badly with other modules wanting to fiddle with this widget. I decided against splitting this up in a base module and a second because we don't have a second in the OCA, and spinning this off should be simple enough. I also believe this changes should be straightforward to migrate to 10.0, where JS tests won't be a horrible torture as in 8.0, where I prefer to abstain from JS tests if not absolutely necessary.

pinging @adrienpeiffer @lmignon to be sure this doesn't remove functionality they conceived for this.

PS: Even if it doesn't look like, this PR reduces LOC