### PR TITLE
[11.0][hr_timesheet_sheet]: allow to display more than 40 cells

### DIFF
--- a/hr_timesheet_sheet/README.rst
+++ b/hr_timesheet_sheet/README.rst
@@ -41,6 +41,10 @@ Known issues / Roadmap
 * When you open the `Summary` or `Details` tab, a save should be performed
   to ensure the data shown is correct. This perhaps could be achieved by including
   a .js file that does that.
+* The timesheet grid is limited to display a max. of 1M cells, due to a
+  limitation of the tree view limit parameter not being able to dynamically
+  set a limit. Since default value of odoo, 40 records is too small, we decided
+  to set 1M, which should be good enough in the majority of scenarios.
 
 Bug Tracker
 ===========

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -54,7 +54,10 @@
                                        field_value="unit_amount"
                                        x_axis_clickable="0"
                                        y_axis_clickable="1">
-                                    <tree>
+                                    <!-- Well this is embarassing... we need to set a huge limit for records to be fetched in
+                                    order to make sure that all rows are going to be displayed. At least until we find a method to
+                                    dynamically define the limit.-->
+                                    <tree limit="1000000">
                                         <field name="value_x"/>
                                         <field name="value_y"/>
                                         <field name="unit_amount"/>
@@ -107,7 +110,6 @@
             </form>
         </field>
     </record>
-
     <record id="view_hr_timesheet_sheet_filter" model="ir.ui.view">
         <field name="name">hr_timesheet.sheet.filter</field>
         <field name="model">hr_timesheet.sheet</field>


### PR DESCRIPTION
With this fix it is possible to display the full grid. Otherwise it was truncatinc the results to 40 cells.