### PR TITLE
[11.0][hr_timesheet_sheet] pass selected project context to task creation

### DIFF
--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -70,7 +70,8 @@
                                 </field>
                                 <group class="oe_edit_only">
                                     <field name="add_line_project_id" domain="[('company_id', '=', company_id)]"/>
-                                    <field name="add_line_task_id" attrs="{'invisible': [('add_line_project_id', '=', False)]}"/>
+                                    <field name="add_line_task_id" attrs="{'invisible': [('add_line_project_id', '=', False)]}"
+                                           context="{'default_project_id': add_line_project_id}"/>
                                     <button name="button_add_line"
                                             type="object"
                                             string="Add new line"


### PR DESCRIPTION
When you create a task from the timesheet sheet, it won't pass on the project to the new task.

With this PR is going to be passed:
![image](https://user-images.githubusercontent.com/7683926/43592925-e412ed38-9676-11e8-8c91-0b65a23b4e2f.png)


![image](https://user-images.githubusercontent.com/7683926/43592947-f04c56ca-9676-11e8-8d14-f429c4826904.png)
