### PR TITLE
[11.0][IMP] hr_timesheet_sheet: ease extensions

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/models/account_analytic_line.py
+++ b/hr_timesheet_sheet/models/account_analytic_line.py
@@ -63,7 +63,7 @@ class AccountAnalyticLine(models.Model):
 
     @api.multi
     def write(self, values):
-        self._check_state()
+        self._check_state_on_write(values)
         return super(AccountAnalyticLine, self).write(values)
 
     @api.multi
@@ -71,13 +71,20 @@ class AccountAnalyticLine(models.Model):
         self._check_state()
         return super(AccountAnalyticLine, self).unlink()
 
+    @api.multi
+    def _check_state_on_write(self, values):
+        """ Hook for extensions """
+        self._check_state()
+
+    @api.multi
     def _check_state(self):
+        if self._context.get('skip_check_state'):
+            return
         for line in self:
             if line.sheet_id and line.sheet_id.state != 'draft':
                 raise UserError(
                     _('You cannot modify an entry in a confirmed '
                       'timesheet sheet.'))
-        return True
 
     @api.multi
     def merge_timesheets(self):

--- a/hr_timesheet_sheet/models/account_analytic_line.py
+++ b/hr_timesheet_sheet/models/account_analytic_line.py
@@ -78,7 +78,7 @@ class AccountAnalyticLine(models.Model):
 
     @api.multi
     def _check_state(self):
-        if self._context.get('skip_check_state'):
+        if self.env.context.get('skip_check_state'):
             return
         for line in self:
             if line.sheet_id and line.sheet_id.state != 'draft':

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -162,8 +162,16 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(sheet.state, 'confirm')
         self.department._compute_timesheet_to_approve()
         self.assertEqual(self.department.timesheet_sheet_to_approve_count, 1)
+
+        # Confirmed timesheet cannot be modified
         with self.assertRaises(UserError):
             timesheet.unit_amount = 0.0
+        self.assertEqual(timesheet.unit_amount, 1.0)
+
+        # Force confirmed timesheet to be modified
+        timesheet.with_context(skip_check_state=True).unit_amount = 0.0
+        self.assertEqual(timesheet.unit_amount, 0.0)
+
         with self.assertRaises(UserError):
             timesheet.unlink()
         sheet.action_timesheet_done()


### PR DESCRIPTION
Module `hr_timesheet_sheet` implements a constraint on the timesheet lines: they cannot be modified in case the timesheet sheet is approved. However in some our customizations, we need to relax a bit this constraint, allowing in some particular cases to write on a timesheet line, even when the timesheet sheet was already approved.

This is a proposal for letting the `def _check_state()` method be skipped.
Also an extra hook method is added, to let the customization modules decide whether `def _check_state()` should be executed or not.

This way the module will be easier to be extended.
