### PR TITLE
[11.0][FIX] hr_timesheet_sheet: fix task domain and default project_id

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.1.1',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -86,7 +86,7 @@
                                     <field name="date"/>
                                     <field name="name"/>
                                     <field name="project_id" required="1"/>
-                                    <field name="task_id"/>
+                                    <field name="task_id" domain="[('project_id', '=', project_id)]" context="{'default_project_id': project_id}"/>
                                     <field name="unit_amount" widget="float_time" string="Hours" sum="Hours"/>
                                     <field name="user_id" invisible="1"/>
                                 </tree>
@@ -95,7 +95,7 @@
                                         <field name="date"/>
                                         <field name="name"/>
                                         <field name="project_id" required="1"/>
-                                        <field name="task_id"/>
+                                        <field name="task_id" domain="[('project_id', '=', project_id)]" context="{'default_project_id': project_id}"/>
                                         <field name="unit_amount" widget="float_time" string="Hours"/>
                                         <field name="user_id" invisible="1"/>
                                     </group>


### PR DESCRIPTION
This PR fixes the view in the details tab of the timesheet sheet:
- When editing the lines, the user is able to select tasks belonging to projects different than the one selected.
- The default_project_id is not passed in context.