### PR TITLE
[11.0][IMP] hr_timesheet_sheet: improve ux

### DIFF
--- a/hr_timesheet_sheet/README.rst
+++ b/hr_timesheet_sheet/README.rst
@@ -66,7 +66,7 @@ Contributors
 ------------
 
 * Miquel Raïch <miquel.raich@eficent.com>
-
+* Andrea Stirpe <a.stirpe@onestein.nl>
 
 Maintainer
 ----------

--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.1.1',
+    'version': '11.0.1.2.0',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -126,14 +126,13 @@ class Sheet(models.Model):
     )
     total_time = fields.Float(
         compute='_compute_total_time',
-        store=True
+        store=True,
     )
 
     @api.depends('timesheet_ids.unit_amount')
     def _compute_total_time(self):
         for sheet in self:
-            sheet.total_time = sum(
-                line.unit_amount for line in sheet.timesheet_ids)
+            sheet.total_time = sum(sheet.mapped('timesheet_ids.unit_amount'))
 
     @api.constrains('date_start', 'date_end')
     def _check_start_end_dates(self):

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -124,6 +124,16 @@ class Sheet(models.Model):
             'draft': [('readonly', False)],
         },
     )
+    total_time = fields.Float(
+        compute='_compute_total_time',
+        store=True
+    )
+
+    @api.depends('timesheet_ids.unit_amount')
+    def _compute_total_time(self):
+        for sheet in self:
+            sheet.total_time = sum(
+                line.unit_amount for line in sheet.timesheet_ids)
 
     @api.constrains('date_start', 'date_end')
     def _check_start_end_dates(self):

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -11,6 +11,7 @@
                 <field name="date_end"/>
                 <field name="department_id" invisible="1"/>
                 <field name="state"/>
+                <field name="total_time"/>
                 <field name="message_needaction" invisible="1"/>
             </tree>
         </field>
@@ -84,9 +85,9 @@
                             <field context="{'employee_id': employee_id, 'user_id':user_id, 'timesheet_date_start': date_start, 'timesheet_date_end': date_end}" name="timesheet_ids" nolabel="1">
                                 <tree editable="bottom" string="Timesheet Activities">
                                     <field name="date"/>
-                                    <field name="name"/>
                                     <field name="project_id" required="1"/>
                                     <field name="task_id" domain="[('project_id', '=', project_id)]" context="{'default_project_id': project_id}"/>
+                                    <field name="name"/>
                                     <field name="unit_amount" widget="float_time" string="Hours" sum="Hours"/>
                                     <field name="user_id" invisible="1"/>
                                 </tree>


### PR DESCRIPTION
The following changes were requested by our customers. In my opinion they could be a generic usability improvement for everyone.

- Add a `Total Time` field in the timesheet sheet list view. It will give a quick overview of the status while filling the timesheet lines.
- In the Details tab, move the Description field after the project and the task. It's a more natural place to be, improving the efficiency when filling the timesheet lines.