### PR TITLE
[11.0][FIX] hr_timesheet_sheet: "Refuse" button name

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.2.0',
+    'version': '11.0.1.2.1',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -371,6 +371,10 @@ class Sheet(models.Model):
         self.write({'state': 'done'})
 
     @api.multi
+    def action_timesheet_refuse(self):
+        return self.action_timesheet_draft()
+
+    @api.multi
     def button_add_line(self):
         for rec in self:
             if rec.state == 'draft':

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -463,3 +463,29 @@ class TestHrTimesheetSheet(TransactionCase):
             sheet.add_line_project_id = project_3
         with self.assertRaises(ValidationError):
             sheet.add_line_task_id = task_3
+
+    def test_9(self):
+        sheet = self.sheet_model.sudo(self.user).create({
+            'employee_id': self.employee.id,
+            'company_id': self.user.company_id.id,
+            'department_id': self.department.id,
+        })
+
+        sheet.add_line_project_id = self.project_1
+        sheet.onchange_add_project_id()
+        sheet.sudo(self.user).button_add_line()
+        sheet._onchange_dates_or_timesheets()
+        sheet.onchange_add_project_id()
+        self.assertEqual(len(sheet.timesheet_ids), 1)
+
+        sheet.action_timesheet_confirm()
+        self.assertEqual(sheet.state, 'confirm')
+
+        sheet.action_timesheet_done()
+        self.assertEqual(sheet.state, 'done')
+        with self.assertRaises(UserError):
+            sheet.unlink()
+
+        sheet.action_timesheet_refuse()
+        self.assertEqual(sheet.state, 'draft')
+        sheet.unlink()

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -27,7 +27,7 @@
                     <button name="action_timesheet_confirm" states="draft" string="Submit to Manager" type="object" class="oe_highlight"/>
                     <button name="action_timesheet_done" states="confirm" string="Approve" type="object" groups="hr_timesheet.group_hr_timesheet_user" class="oe_highlight"/>
                     <button name="action_timesheet_draft" states="done" string="Set to Draft" type="object" groups="hr_timesheet.group_hr_timesheet_user"/>
-                    <button name="action_timesheet_draft" states="confirm" string="Refuse" type="object" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <button name="action_timesheet_refuse" states="confirm" string="Refuse" type="object" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirm,done"/>
                 </header>
                 <sheet>


### PR DESCRIPTION
The "Refuse" button name is wrong, causing troubles when trying to change the button attributes.