### PR TITLE
[11.0][hr_timesheet_sheet] add domain to project, to restrict the selection of projects to only the ones that have 'allow_timesheet' to true.

### DIFF
--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -75,10 +75,12 @@ class TestHrTimesheetSheet(TransactionCase):
         self.project_1 = self.project_model.create({
             'name': "Project 1",
             'company_id': self.user.company_id.id,
+            'allow_timesheets': True,
         })
         self.project_2 = self.project_model.create({
             'name': "Project 2",
             'company_id': self.user.company_id.id,
+            'allow_timesheets': True,
         })
         self.task_1 = self.task_model.create({
             'name': "Task 1",

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -70,7 +70,7 @@
                                     </tree>
                                 </field>
                                 <group class="oe_edit_only">
-                                    <field name="add_line_project_id" domain="[('company_id', '=', company_id)]"/>
+                                    <field name="add_line_project_id" domain="[('company_id', '=', company_id), ('allow_timesheets', '=', True)]"/>
                                     <field name="add_line_task_id" attrs="{'invisible': [('add_line_project_id', '=', False)]}"
                                            context="{'default_project_id': add_line_project_id}"/>
                                     <button name="button_add_line"


### PR DESCRIPTION
Without this fix it was possible to add a project to a timesheet that did not have this flag set.