### PR TITLE
[FIX] Fix related fields in hr_timesheet_sheet

### DIFF
--- a/hr_timesheet_sheet/models/res_config.py
+++ b/hr_timesheet_sheet/models/res_config.py
@@ -10,9 +10,11 @@ class ResConfig(models.TransientModel):
     sheet_range = fields.Selection(
         related='company_id.sheet_range',
         string="Timesheet Sheet Range",
-        help="The range of your Timesheet Sheet.")
+        help="The range of your Timesheet Sheet.",
+        readonly=False)
 
     timesheet_week_start = fields.Selection(
         related='company_id.timesheet_week_start',
         string="Week Start Day",
-        help="Starting day for Timesheet Sheets.")
+        help="Starting day for Timesheet Sheets.",
+        readonly=False)


### PR DESCRIPTION
This PR fixes an error due to related fields being readonly=True by default in Odoo v12