### PR TITLE
[11.0][FIX] hr_timesheet_sheet: fix lines inconsistency

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.2.1',
+    'version': '11.0.1.2.2',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/models/account_analytic_line.py
+++ b/hr_timesheet_sheet/models/account_analytic_line.py
@@ -8,62 +8,37 @@ from odoo.exceptions import UserError
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
 
-    sheet_id_computed = fields.Many2one(
-        comodel_name='hr_timesheet.sheet',
-        string='Sheet',
-        compute='_compute_sheet',
-        index=True,
-        ondelete='cascade',
-        search='_search_sheet'
-    )
     sheet_id = fields.Many2one(
         comodel_name='hr_timesheet.sheet',
         string='Sheet',
-        compute='_compute_sheet',
-        store=True,
     )
 
-    @api.depends('date', 'user_id', 'project_id', 'task_id', 'company_id',
-                 'sheet_id.date_start', 'sheet_id.date_end',
-                 'sheet_id.employee_id', 'sheet_id.company_id')
     def _compute_sheet(self):
         """Links the timesheet line to the corresponding sheet"""
         for timesheet in self:
-            if timesheet.sheet_id or not timesheet.project_id:
+            if not timesheet.project_id:
                 continue
-            sheets = self.env['hr_timesheet.sheet'].search(
-                [('date_end', '>=', timesheet.date),
-                 ('date_start', '<=', timesheet.date),
-                 ('employee_id.user_id.id', '=', timesheet.user_id.id),
-                 ('company_id', 'in', [timesheet.company_id.id, False]),
-                 ('state', '=', 'draft'),
-                 ])
-            if sheets:
-                timesheet.sheet_id_computed = sheets[0]
-                timesheet.sheet_id = sheets[0]
+            sheet = self.env['hr_timesheet.sheet'].search([
+                ('date_end', '>=', timesheet.date),
+                ('date_start', '<=', timesheet.date),
+                ('employee_id', '=', timesheet.employee_id.id),
+                ('company_id', 'in', [timesheet.company_id.id, False]),
+                ('state', '=', 'draft'),
+            ], limit=1)
+            timesheet.sheet_id = sheet
 
-    def _search_sheet(self, operator, value):
-        assert operator == 'in'
-        ids = []
-        for ts in self.env['hr_timesheet.sheet'].browse(value):
-            self._cr.execute("""
-                    SELECT l.id
-                        FROM account_analytic_line l
-                    WHERE %(date_end)s >= l.date
-                        AND %(date_start)s <= l.date
-                        AND %(user_id)s = l.user_id
-                        AND %(company_id)s = l.company_id
-                    GROUP BY l.id""", {'date_start': ts.date_start,
-                                       'date_end': ts.date_end,
-                                       'user_id': ts.employee_id.user_id.id,
-                                       'company_id': ts.company_id.id,
-                                       })
-            ids.extend([row[0] for row in self._cr.fetchall()])
-        return [('id', 'in', ids)]
+    @api.model
+    def create(self, values):
+        res = super(AccountAnalyticLine, self).create(values)
+        res._compute_sheet()
+        return res
 
     @api.multi
     def write(self, values):
         self._check_state_on_write(values)
+        vals_do_compute = ['date', 'employee_id', 'project_id', 'company_id']
+        if any(val in vals_do_compute for val in values):
+            self._compute_sheet()
         return super(AccountAnalyticLine, self).write(values)
 
     @api.multi

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -195,11 +195,16 @@ class TestHrTimesheetSheet(TransactionCase):
             'company_id': self.user.company_id.id,
             'date_start': self.sheet_model._default_date_start(),
             'date_end': self.sheet_model._default_date_end(),
+            'state': 'draft',
         })
         sheet._onchange_dates_or_timesheets()
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 0)
         self.assertTrue(self.aal_model.search([('id', '=', timesheet.id)]))
+
+        sheet._onchange_line_ids()
+        self.assertEqual(len(sheet.line_ids), 7)
+        self.assertEqual(len(sheet.timesheet_ids), 1)
 
         sheet = self.sheet_model.sudo(self.user).create(
             sheet._convert_to_write(sheet._cache))
@@ -412,6 +417,7 @@ class TestHrTimesheetSheet(TransactionCase):
             'company_id': self.user.company_id.id,
             'date_start': self.sheet_model._default_date_end(),
             'date_end': self.sheet_model._default_date_start(),
+            'state': 'draft',
         })
         sheet._onchange_dates_or_timesheets()
         self.assertEqual(len(sheet.line_ids), 0)

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -69,7 +69,7 @@
                                         <field name="count_timesheets"/>
                                     </tree>
                                 </field>
-                                <group class="oe_edit_only">
+                                <group class="oe_edit_only" attrs="{'invisible': [('state', '!=', 'draft')]}">
                                     <field name="add_line_project_id" domain="[('company_id', '=', company_id), ('allow_timesheets', '=', True)]"/>
                                     <field name="add_line_task_id" attrs="{'invisible': [('add_line_project_id', '=', False)]}"
                                            context="{'default_project_id': add_line_project_id}"/>


### PR DESCRIPTION
We sometimes noticed inconsistencies between the amounts displayed in tab Summary (the matrix) and the amounts displayed in tab Details.

When it happened, we noticed that the amounts in Details are lower than the ones in Summary because some timesheet lines (`account.analytic.line`) are missing in tab Details. By reloading the page (F5 in the browser), the problem is automagically fixed: the missing lines reappear so that the amounts in Details are recalculated the same way as in Summary.

That strange behavior is caused by an inconsistency between the two fields of model `hr_timesheet.sheet`:

- `timesheet_ids` (One2many)
- `line_ids` (One2many)

The calculation of the fields above id delegated to the two methods:

- `def _compute_sheet()` in model `account.analytic.line` (that determines `timesheet_ids`)
- `def _compute_line_ids()` in model `hr_timesheet.sheet` (that calculates the `line_ids`)

This PR fixes the computation of `def _compute_sheet()`, making it consistent with the other one.
