### PR TITLE
[12.0][FIX] hr_timesheet_sheet: unlink only generated AAL

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -1,10 +1,10 @@
 # Copyright 2018 Eficent
-# Copyright 2018 Brainbean Apps
+# Copyright 2018-2019 Brainbean Apps
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '12.0.1.0.2',
+    'version': '12.0.1.0.3',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -361,7 +361,7 @@ class Sheet(models.Model):
         analytic_timesheet_toremove = self.env['account.analytic.line']
         for sheet in self:
             analytic_timesheet_toremove += \
-                sheet.timesheet_ids.filtered(lambda t: not t.task_id)
+                sheet.timesheet_ids.filtered(lambda t: t.name == '/')
         analytic_timesheet_toremove.unlink()
         return super().unlink()
 


### PR DESCRIPTION
Unlinking non-generated ALLs are very bad