### PR TITLE
[12.0][IMP] hr_timesheet_sheet: different validation models

### DIFF
--- a/hr_timesheet_sheet/README.rst
+++ b/hr_timesheet_sheet/README.rst
@@ -25,10 +25,13 @@ HR Timesheet Sheet
 
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
-This module supplies a new screen enabling you to manage your work encoding (timesheet) by period.
-Timesheet entries are made by employees each day. At the end of the defined period,
-employees validate their sheet and the manager must then approve his team's entries.
-Periods are defined in the company forms and you can set them to run monthly, weekly or daily.
+This module supplies a new screen enabling you to manage your work encoding
+(timesheet) by period. Timesheet entries are made by employees each day. At the
+end of the defined period, employees submit their validated sheet and the
+reviewer must then approve submitted entries. Periods are defined in the
+company forms and you can set them to run monthly, weekly or daily. Reviewer is
+configurable to be HR Officer/Manager, Department Manager, Direct Manager, or
+Project Manager.
 
 **Table of contents**
 
@@ -51,6 +54,9 @@ If you want other default ranges different from weekly, you need to go:
 * In the menu `Configuration` -> `Settings` -> **Timesheet Options**,
   and select in **Timesheet Sheet Range** the default range you want.
 * When you have a weekly range you can also specify the **Week Start Day**.
+
+To change who reviews submitted sheets, go to *Configuration > Settings > Timesheet Options*
+and configure **Timesheet Sheet Review Policy** accordingly.
 
 Usage
 =====

--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '12.0.2.1.2',
+    'version': '12.0.3.0.0',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/data/hr_timesheet_sheet_data.xml
+++ b/hr_timesheet_sheet/data/hr_timesheet_sheet_data.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo noupdate="1">
-    <!--
-        License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-    -->
+<!--
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
 
     <!-- Timesheet sheet related subtypes for messaging / Chatter -->
     <record id="mt_timesheet_confirmed" model="mail.message.subtype">
-        <field name="name">Waiting Approval</field>
+        <field name="name">Waiting Review</field>
         <field name="res_model">hr_timesheet.sheet</field>
         <field name="default" eval="True"/>
-        <field name="description">waiting approval</field>
+        <field name="description">Waiting review</field>
     </record>
     <record id="mt_timesheet_approved" model="mail.message.subtype">
         <field name="name">Approved</field>

--- a/hr_timesheet_sheet/models/res_company.py
+++ b/hr_timesheet_sheet/models/res_company.py
@@ -31,3 +31,15 @@ class ResCompany(models.Model):
         selection=_WEEKDAYS,
         string='Week start day',
         default='0')
+
+    timesheet_sheet_review_policy = fields.Selection(
+        string='Timesheet Sheet Review Policy',
+        selection=[
+            ('hr', 'By HR Manager/Officer'),
+            ('department_manager', 'By Department Manager'),
+            ('direct_manager', 'By Direct Manager'),
+            ('project_manager', 'By Project Manager'),
+        ],
+        default='hr',
+        help='How Timesheet Sheets review is performed.',
+    )

--- a/hr_timesheet_sheet/models/res_config.py
+++ b/hr_timesheet_sheet/models/res_config.py
@@ -19,3 +19,8 @@ class ResConfig(models.TransientModel):
         string="Week Start Day",
         help="Starting day for Timesheet Sheets.",
         readonly=False)
+
+    timesheet_sheet_review_policy = fields.Selection(
+        related='company_id.timesheet_sheet_review_policy',
+        readonly=False,
+    )

--- a/hr_timesheet_sheet/readme/CONFIGURE.rst
+++ b/hr_timesheet_sheet/readme/CONFIGURE.rst
@@ -3,3 +3,6 @@ If you want other default ranges different from weekly, you need to go:
 * In the menu `Configuration` -> `Settings` -> **Timesheet Options**,
   and select in **Timesheet Sheet Range** the default range you want.
 * When you have a weekly range you can also specify the **Week Start Day**.
+
+To change who reviews submitted sheets, go to *Configuration > Settings > Timesheet Options*
+and configure **Timesheet Sheet Review Policy** accordingly.

--- a/hr_timesheet_sheet/readme/DESCRIPTION.rst
+++ b/hr_timesheet_sheet/readme/DESCRIPTION.rst
@@ -1,4 +1,7 @@
-This module supplies a new screen enabling you to manage your work encoding (timesheet) by period.
-Timesheet entries are made by employees each day. At the end of the defined period,
-employees validate their sheet and the manager must then approve his team's entries.
-Periods are defined in the company forms and you can set them to run monthly, weekly or daily.
+This module supplies a new screen enabling you to manage your work encoding
+(timesheet) by period. Timesheet entries are made by employees each day. At the
+end of the defined period, employees submit their validated sheet and the
+reviewer must then approve submitted entries. Periods are defined in the
+company forms and you can set them to run monthly, weekly or daily. Reviewer is
+configurable to be HR Officer/Manager, Department Manager, Direct Manager, or
+Project Manager.

--- a/hr_timesheet_sheet/static/description/index.html
+++ b/hr_timesheet_sheet/static/description/index.html
@@ -368,10 +368,13 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/timesheet/tree/12.0/hr_timesheet_sheet"><img alt="OCA/timesheet" src="https://img.shields.io/badge/github-OCA%2Ftimesheet-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/timesheet-12-0/timesheet-12-0-hr_timesheet_sheet"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/117/12.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
-<p>This module supplies a new screen enabling you to manage your work encoding (timesheet) by period.
-Timesheet entries are made by employees each day. At the end of the defined period,
-employees validate their sheet and the manager must then approve his team’s entries.
-Periods are defined in the company forms and you can set them to run monthly, weekly or daily.</p>
+<p>This module supplies a new screen enabling you to manage your work encoding
+(timesheet) by period. Timesheet entries are made by employees each day. At the
+end of the defined period, employees submit their validated sheet and the
+reviewer must then approve submitted entries. Periods are defined in the
+company forms and you can set them to run monthly, weekly or daily. Reviewer is
+configurable to be HR Officer/Manager, Department Manager, Direct Manager, or
+Project Manager.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -404,6 +407,8 @@ Github: <a class="reference external" href="https://github.com/OCA/web/tree/11.0
 and select in <strong>Timesheet Sheet Range</strong> the default range you want.</li>
 <li>When you have a weekly range you can also specify the <strong>Week Start Day</strong>.</li>
 </ul>
+<p>To change who reviews submitted sheets, go to <em>Configuration &gt; Settings &gt; Timesheet Options</em>
+and configure <strong>Timesheet Sheet Review Policy</strong> accordingly.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id3">Usage</a></h1>

--- a/hr_timesheet_sheet/views/account_analytic_line_views.xml
+++ b/hr_timesheet_sheet/views/account_analytic_line_views.xml
@@ -29,4 +29,39 @@
         </field>
     </record>
 
+    <record id="act_hr_timesheet_line_to_submit" model="ir.actions.act_window">
+        <field name="name">Timesheets to Submit</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">account.analytic.line</field>
+        <field name="view_type">form</field>
+        <field name="view_id" eval="False"/>
+        <field name="context">
+            {
+                'search_default_week': 1,
+                'search_default_groupby_employee': 1,
+                'search_default_groupby_project': 1,
+            }
+        </field>
+        <field name="domain">[('project_id.active','=',True),'|',('sheet_id','=',False),('sheet_id.state','=','draft')]</field>
+        <field name="help" type="html">
+          <p class="oe_view_nocontent_create">
+            Timesheets to submit.
+          </p><p>
+            Employees must record timesheets every day and confirm at the end
+            of the repording period. Once the timesheet sheet is confirmed, it should be
+            validated by a reviewer.
+          </p><p>
+            Timesheets can also be invoiced to customers, depending on the
+            configuration of each project's related contract.
+          </p>
+        </field>
+    </record>
+
+    <menuitem
+        action="act_hr_timesheet_line_to_submit"
+        id="menu_act_hr_timesheet_line_to_submit"
+        parent="menu_hr_to_review"
+        sequence="21"
+    />
+
 </odoo>

--- a/hr_timesheet_sheet/views/hr_department_views.xml
+++ b/hr_timesheet_sheet/views/hr_department_views.xml
@@ -5,14 +5,14 @@
     -->
 
     <record id="hr_timesheet_action_from_department" model="ir.actions.act_window">
-        <field name="name">Timesheets to Approve</field>
+        <field name="name">Timesheets to Review</field>
         <field name="res_model">hr_timesheet.sheet</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
         <field name="context">{
             'search_default_department_id': [active_id],
             'default_department_id': active_id,
-            'search_default_to_approve': 1}
+            'search_default_to_review': 1}
         </field>
     </record>
 

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -7,7 +7,7 @@
 -->
 <odoo>
 
-    <record id="hr_timesheet_sheet_tree_simplified" model="ir.ui.view">
+    <record id="hr_timesheet_sheet_tree" model="ir.ui.view">
         <field name="name">hr.timesheet.sheet.tree</field>
         <field name="model">hr_timesheet.sheet</field>
         <field name="arch" type="xml">
@@ -19,8 +19,11 @@
             >
                 <field name="employee_id"/>
                 <field name="name" string="Period"/>
+                <field name="project_id" invisible="1"/>
+                <field name="department_id" invisible="1"/>
                 <field name="date_start"/>
                 <field name="date_end"/>
+                <field name="reviewer_id"/>
                 <field name="state"/>
                 <field name="total_time" widget="float_time"/>
                 <field name="message_needaction" invisible="1"/>
@@ -28,18 +31,54 @@
         </field>
     </record>
 
+    <record id="hr_timesheet_sheet_tree_my" model="ir.ui.view">
+        <field name="name">hr.timesheet.sheet.tree.my</field>
+        <field name="model">hr_timesheet.sheet</field>
+        <field name="inherit_id" ref="hr_timesheet_sheet_tree"/>
+        <field name="mode">primary</field>
+        <field name="priority">1000</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='employee_id']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="hr_timesheet_sheet_form" model="ir.ui.view">
         <field name="name">hr_timesheet.sheet.form</field>
         <field name="model">hr_timesheet.sheet</field>
-        <field name="priority">1</field>
         <field name="arch" type="xml">
             <form string="Timesheet Sheet">
+                <field name="can_review" invisible="1"/>
                 <field name="user_id" invisible="1"/>
+                <field name="review_policy" invisible="1"/>
                 <header>
-                    <button name="action_timesheet_confirm" states="draft" string="Submit to Manager" type="object" class="oe_highlight"/>
-                    <button name="action_timesheet_done" states="confirm" string="Approve" type="object" groups="hr_timesheet.group_timesheet_manager" class="oe_highlight"/>
-                    <button name="action_timesheet_draft" states="done" string="Set to Draft" type="object" groups="hr_timesheet.group_timesheet_manager"/>
-                    <button name="action_timesheet_refuse" states="confirm" string="Refuse" type="object" groups="hr_timesheet.group_timesheet_manager"/>
+                    <button
+                        name="action_timesheet_confirm"
+                        string="Submit to Reviewer"
+                        type="object"
+                        class="oe_highlight"
+                        attrs="{'invisible': [('state', '!=', 'draft')]}"
+                    />
+                    <button
+                        name="action_timesheet_done"
+                        string="Approve"
+                        type="object"
+                        class="oe_highlight"
+                        attrs="{'invisible': ['|', ('can_review', '!=', True), ('state', '!=', 'confirm')]}"
+                    />
+                    <button
+                        name="action_timesheet_draft"
+                        string="Set to Draft"
+                        type="object"
+                        attrs="{'invisible': ['|', ('can_review', '!=', True), ('state', '!=', 'done')]}"
+                    />
+                    <button
+                        name="action_timesheet_refuse"
+                        string="Refuse"
+                        type="object"
+                        attrs="{'invisible': ['|', ('can_review', '!=', True), ('state', '!=', 'confirm')]}"
+                    />
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirm,done"/>
                 </header>
                 <sheet>
@@ -51,7 +90,10 @@
                         <group name="dates">
                             <label for="date_start" string="Timesheet Period"/>
                             <div style="display: inline;"><field name="date_start" class="oe_inline"/> to <field name="date_end" class="oe_inline"/></div>
-                            <field name="department_id" invisible="1"/>
+                        </group>
+                        <group name="details">
+                            <field name="department_id" attrs="{'invisible': [('review_policy', '!=', 'department_manager')], 'required': [('review_policy', '=', 'department_manager')]}"/>
+                            <field name="project_id" attrs="{'invisible': [('review_policy', '!=', 'project_manager')], 'required': [('review_policy', '=', 'project_manager')]}"/>
                             <field name="company_id" groups="base.group_multi_company" force_save="1"/>
                         </group>
                     </group>
@@ -86,6 +128,7 @@
                                     <field
                                         name="add_line_project_id"
                                         domain="[('company_id', '=', company_id), ('allow_timesheets', '=', True)]"
+                                        attrs="{'invisible': [('review_policy', '=', 'project_manager')]}"
                                     />
                                     <field
                                         name="add_line_task_id"
@@ -108,7 +151,7 @@
                                 context="{'user_id': user_id}">
                                 <tree editable="bottom" string="Timesheet Activities">
                                     <field name="date"/>
-                                    <field name="project_id" required="1"/>
+                                    <field name="project_id" required="1" attrs="{'column_invisible': [('parent.review_policy', '=', 'project_manager')]}"/>
                                     <field name="task_id" domain="[('project_id', '=', project_id)]" context="{'default_project_id': project_id}"/>
                                     <field name="name"/>
                                     <field name="unit_amount" widget="float_time" string="Hours" sum="Hours"/>
@@ -118,7 +161,7 @@
                                     <group>
                                         <field name="date"/>
                                         <field name="name"/>
-                                        <field name="project_id" required="1"/>
+                                        <field name="project_id" required="1" attrs="{'column_invisible': [('parent.review_policy', '=', 'project_manager')]}"/>
                                         <field name="task_id" domain="[('project_id', '=', project_id)]" context="{'default_project_id': project_id}"/>
                                         <field name="unit_amount" widget="float_time" string="Hours"/>
                                         <field name="user_id" invisible="1"/>
@@ -135,20 +178,39 @@
             </form>
         </field>
     </record>
+
+    <record id="hr_timesheet_sheet_form_my" model="ir.ui.view">
+        <field name="name">hr.timesheet.sheet.form.my</field>
+        <field name="model">hr_timesheet.sheet</field>
+        <field name="inherit_id" ref="hr_timesheet_sheet_form"/>
+        <field name="mode">primary</field>
+        <field name="priority">1000</field>
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('oe_title')]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="view_hr_timesheet_sheet_filter" model="ir.ui.view">
         <field name="name">hr_timesheet.sheet.filter</field>
         <field name="model">hr_timesheet.sheet</field>
         <field name="arch" type="xml">
             <search string="Search Timesheet">
                 <field name="date_start"/>
-                <filter name="draft" string="In Draft" domain="[('state','=','draft')]" help="Unvalidated Timesheet Sheets"/>
-                <filter name="to_approve" string="To Approve" domain="[('state','=','confirm')]" help="Confirmed Timesheet Sheets" groups="hr_timesheet.group_timesheet_manager"/>
+                <filter name="draft" string="In Draft" domain="[('state','=','draft')]" help="Draft Timesheet Sheets"/>
+                <filter name="confirm" string="Submitted" domain="[('state','=','confirm')]" help="Submitted Timesheet Sheets"/>
+                <filter name="to_review" string="To Review" domain="[('state','=','confirm')]" help="Timesheet Sheets to Review"/>
                 <filter name="message_needaction" string="Unread Messages" domain="[('message_needaction','=',True)]"/>
                 <field name="employee_id"/>
                 <field name="department_id"/>
+                <field name="project_id"/>
+                <field name="reviewer_id"/>
                 <group expand="0" string="Group By">
                     <filter name="groupby_employees" string="Employees" domain="[]" context="{'group_by':'employee_id'}"/>
                     <filter name="groupby_department" string="Department" domain="[]" context="{'group_by':'department_id'}"/>
+                    <filter name="groupby_project" string="Project" domain="[]" context="{'group_by':'project_id'}"/>
+                    <filter name="groupby_reviewer" string="Reviewer" domain="[]" context="{'group_by':'reviewer_id'}"/>
                 </group>
             </search>
         </field>
@@ -166,13 +228,27 @@
              New timesheet sheet.
             </p><p>
              You must record timesheets in the sheet every day and confirm at the end
-             of the week. Once the timesheet sheet is confirmed, it should be
-             validated by a manager.
+             of the repording period. Once the timesheet sheet is confirmed, it should be
+             validated by a reviewer.
             </p><p>
              Timesheet sheets can also be invoiced to customers, depending on
              the configuration of each project's related contract.
             </p>
         </field>
+    </record>
+
+    <record id="act_hr_timesheet_sheet_my_timesheets_tree" model="ir.actions.act_window.view">
+        <field name="view_mode">tree</field>
+        <field name="sequence" eval="4"/>
+        <field name="view_id" ref="hr_timesheet_sheet_tree_my"/>
+        <field name="act_window_id" ref="act_hr_timesheet_sheet_my_timesheets"/>
+    </record>
+
+    <record id="act_hr_timesheet_sheet_my_timesheets_form" model="ir.actions.act_window.view">
+        <field name="view_mode">form</field>
+        <field name="sequence" eval="5"/>
+        <field name="view_id" ref="hr_timesheet_sheet_form_my"/>
+        <field name="act_window_id" ref="act_hr_timesheet_sheet_my_timesheets"/>
     </record>
 
     <record id="act_hr_timesheet_sheet_all_timesheets" model="ir.actions.act_window">
@@ -186,8 +262,8 @@
              Timesheet sheets.
             </p><p>
              Employees must record timesheets in the sheet every day and confirm at the end
-             of the week. Once the timesheet sheet is confirmed, it should be
-             validated by a manager.
+             of the repording period. Once the timesheet sheet is confirmed, it should be
+             validated by a reviewer.
             </p><p>
              Timesheet sheets can also be invoiced to customers, depending on
              the configuration of each project's related contract.
@@ -210,21 +286,22 @@
         groups="hr_timesheet.group_timesheet_manager"
     />
 
-    <record id="act_hr_timesheet_sheet_form" model="ir.actions.act_window">
-        <field name="name">Timesheet Sheets to Approve</field>
+    <record id="act_hr_timesheet_sheet_to_review" model="ir.actions.act_window">
+        <field name="name">Timesheet Sheets to Review</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">hr_timesheet.sheet</field>
         <field name="view_type">form</field>
         <field name="view_id" eval="False"/>
-        <field name="context">{'search_default_to_approve':1}</field>
+        <field name="context">{'search_default_to_review':1}</field>
+        <field name="domain">[('can_review','=',True)]</field>
         <field name="search_view_id" ref="view_hr_timesheet_sheet_filter"/>
         <field name="help" type="html">
           <p class="oe_view_nocontent_create">
-            Timesheets to approve.
+            Timesheets to review.
           </p><p>
             Employees must record timesheets every day and confirm at the end
-            of the week. Once the timesheet sheet is confirmed, it should be
-            validated by a manager.
+            of the repording period. Once the timesheet sheet is confirmed, it should be
+            validated by a reviewer.
           </p><p>
             Timesheets can also be invoiced to customers, depending on the
             configuration of each project's related contract.
@@ -233,17 +310,16 @@
     </record>
 
     <menuitem
-        id="menu_hr_to_approve"
-        name="To Approve"
+        id="menu_hr_to_review"
+        name="To Review"
         parent="hr_timesheet.timesheet_menu_root"
         sequence="7"
-        groups="hr_timesheet.group_timesheet_manager"
     />
 
     <menuitem
-        action="act_hr_timesheet_sheet_form"
-        id="menu_act_hr_timesheet_sheet_form"
-        parent="menu_hr_to_approve"
+        action="act_hr_timesheet_sheet_to_review"
+        id="menu_act_hr_timesheet_sheet_to_review"
+        parent="menu_hr_to_review"
         sequence="11"
     />
 

--- a/hr_timesheet_sheet/views/res_config_settings_views.xml
+++ b/hr_timesheet_sheet/views/res_config_settings_views.xml
@@ -42,6 +42,20 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_right_pane">
+                            <label for="timesheet_sheet_review_policy"/>
+                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
+                            <div class="text-muted">
+                                Choose timesheet sheets review policy.
+                            </div>
+                            <div class="content-group">
+                                <div class="mt16">
+                                    <field name="timesheet_sheet_review_policy" class="o_light_label" widget="radio" required="1"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
This module adds option to configure how the timesheet sheet validation is done. Reviewer is
configurable to be HR Officer/Manager, Department Manager, Direct Manager, or
Project Manager.


To change who reviews submitted sheets, go to *Configuration > Settings > Timesheet Options*
and configure **Timesheet Sheet Review Policy** accordingly.
