### PR TITLE
[11.0][IMP] hr_timesheet_sheet: fix amount calculation issues + code simplification

### DIFF
--- a/hr_timesheet_sheet/README.rst
+++ b/hr_timesheet_sheet/README.rst
@@ -11,8 +11,6 @@ Timesheet entries are made by employees each day. At the end of the defined peri
 employees validate their sheet and the manager must then approve his team's entries.
 Periods are defined in the company forms and you can set them to run monthly, weekly or daily.
 
-Negative hours are not admitted.
-
 Installation
 ============
 
@@ -39,9 +37,9 @@ If you want other default ranges different from weekly, you need to go:
 Known issues / Roadmap
 ======================
 
-* When you open the `Summary` or `Details` tab, a save should be performed
-  to ensure the data shown is correct. This perhaps could be achieved by including
-  a .js file that does that.
+* When you change values on the `Summary` tab, a save should be performed
+  to ensure the data shown on the `Details` tab is correct. This limitation could be
+  perhaps avoided by including a .js file that aligns the `Details` tab.
 * The timesheet grid is limited to display a max. of 1M cells, due to a
   limitation of the tree view limit parameter not being able to dynamically
   set a limit. Since default value of odoo, 40 records is too small, we decided

--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -4,12 +4,12 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.2.5',
+    'version': '11.0.1.3.0',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',
     'license': 'AGPL-3',
-    'author': 'Eficent, Odoo Community Association (OCA)',
+    'author': 'Eficent, Onestein, Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/hr-timesheet',
     'depends': [
         'hr_timesheet',

--- a/hr_timesheet_sheet/models/account_analytic_line.py
+++ b/hr_timesheet_sheet/models/account_analytic_line.py
@@ -23,7 +23,7 @@ class AccountAnalyticLine(models.Model):
                 ('date_start', '<=', timesheet.date),
                 ('employee_id', '=', timesheet.employee_id.id),
                 ('company_id', 'in', [timesheet.company_id.id, False]),
-                ('state', '=', 'draft'),
+                ('state', 'in', ['new', 'draft']),
             ], limit=1)
             if timesheet.sheet_id != sheet:
                 timesheet.sheet_id = sheet
@@ -80,7 +80,7 @@ class AccountAnalyticLine(models.Model):
         if self.env.context.get('skip_check_state'):
             return
         for line in self:
-            if line.sheet_id and line.sheet_id.state != 'draft':
+            if line.sheet_id and line.sheet_id.state not in ['new', 'draft']:
                 raise UserError(
                     _('You cannot modify an entry in a confirmed '
                       'timesheet sheet.'))

--- a/hr_timesheet_sheet/models/hr_employee.py
+++ b/hr_timesheet_sheet/models/hr_employee.py
@@ -16,9 +16,10 @@ class HrEmployee(models.Model):
 
     @api.multi
     def _compute_timesheet_count(self):
+        Sheet = self.env['hr_timesheet.sheet']
         for employee in self:
-            employee.timesheet_count = employee.env['hr_timesheet.sheet'].\
-                search_count([('employee_id', '=', employee.id)])
+            employee.timesheet_count = Sheet.search_count([
+                ('employee_id', '=', employee.id)])
 
     @api.constrains('company_id')
     def _check_company_id(self):

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -241,57 +241,44 @@ class Sheet(models.Model):
 
     def _get_timesheet_sheet_lines_domain(self):
         self.ensure_one()
-        domain = [
+        return [
             ('project_id', '!=', False),
             ('date', '<=', self.date_end),
             ('date', '>=', self.date_start),
             ('employee_id', '=', self.employee_id.id),
             ('company_id', '=', self.company_id.id),
         ]
-        return domain
 
     @api.multi
     def _compute_line_ids(self):
         for sheet in self:
             if not all([sheet.date_start, sheet.date_end]):
                 continue
-            dates = sheet._get_dates()
-            if not dates:
-                continue
-            data_matrix = {}
-            projects = sheet.timesheet_ids.mapped('project_id')
-            for date in dates:
-                for project in projects:
-                    project_timesheets = sheet.timesheet_ids.filtered(
-                        lambda x: x.project_id == project)
-                    tasks = [project_timesheets.mapped('task_id')]
-                    if not project_timesheets or not all(
-                            [t.task_id for t in project_timesheets]):
-                        tasks += [self.env['project.task']]
-                    for task in tasks:
-                        timesheets = project_timesheets.filtered(
-                            lambda t: date == t.date
-                            and t.task_id == task)
-                        unit_amount = sum(t.unit_amount for t in timesheets)
-                        data_matrix[(date, project, task)] = {
-                            'unit_amount': unit_amount,
-                            'timesheets': timesheets
-                        }
-            sheet.line_ids = sheet._create_data_matrix_lines(data_matrix)
+            matrix = sheet._get_data_matrix()
+            lines = self.env['hr_timesheet.sheet.line']
+            for item in sorted(matrix, key=lambda l: self._sort_matrix(l)):
+                vals = sheet._get_default_sheet_line(matrix, item)
+                lines |= self.env['hr_timesheet.sheet.line'].create(vals)
+                sheet.clean_timesheets(matrix[item])
+            sheet.line_ids = lines
 
-    def _create_data_matrix_lines(self, data_matrix):
+    def _sort_matrix(self, line):
+        return [line[0], line[1].name, line[2].name or '']
+
+    def _get_data_matrix(self):
         self.ensure_one()
-        lines = self.env['hr_timesheet.sheet.line']
-        for item in data_matrix:
-            lines |= self.env['hr_timesheet.sheet.line'].create(
-                self._get_default_sheet_line(
-                    date=item[0],
-                    project=item[1],
-                    task=item[2],
-                    unit_amount=data_matrix[item]['unit_amount']
-                ))
-            self.clean_timesheets(data_matrix[item]['timesheets'])
-        return lines
+        matrix = {}
+        empty_line = self.env['account.analytic.line']
+        for line in self.timesheet_ids:
+            data_key = (line.date, line.project_id, line.task_id)
+            if data_key not in matrix:
+                matrix[data_key] = empty_line
+            matrix[data_key] += line
+        for date in self._get_dates():
+            for item in matrix.copy():
+                if (date, item[1], item[2]) not in matrix:
+                    matrix[(date, item[1], item[2])] = empty_line
+        return matrix
 
     @api.onchange('date_start', 'date_end', 'employee_id')
     def _onchange_dates(self):
@@ -445,20 +432,17 @@ class Sheet(models.Model):
             name += ' - {}'.format(task.name)
         return name
 
-    def _get_default_sheet_line(self, date, project, task, unit_amount):
-        name_y = self._get_line_name(project, task)
+    def _get_default_sheet_line(self, matrix, item):
         values = {
-            'value_x': self._get_date_name(date),
-            'value_y': name_y,
-            'date': date,
-            'project_id': project.id,
-            'task_id': task.id,
-            'unit_amount': unit_amount,
+            'value_x': self._get_date_name(item[0]),
+            'value_y': self._get_line_name(item[1], item[2]),
+            'date': item[0],
+            'project_id': item[1].id,
+            'task_id': item[2].id,
+            'unit_amount': sum(t.unit_amount for t in matrix[item]),
         }
         if self.id:
-            values.update({
-                'sheet_id': self.id,
-            })
+            values.update({'sheet_id': self.id})
         return values
 
     @api.model

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -379,6 +379,12 @@ class Sheet(models.Model):
         analytic_timesheet_toremove.unlink()
         return super(Sheet, self).unlink()
 
+    def _timesheet_subscribe_users(self):
+        for sheet in self:
+            if sheet.employee_id.parent_id.user_id:
+                self.message_subscribe_users(
+                    user_ids=[sheet.employee_id.parent_id.user_id.id])
+
     @api.multi
     def action_timesheet_draft(self):
         if not self.env.user.has_group('hr_timesheet.group_hr_timesheet_user'):
@@ -389,10 +395,7 @@ class Sheet(models.Model):
 
     @api.multi
     def action_timesheet_confirm(self):
-        for sheet in self:
-            if sheet.employee_id.parent_id.user_id:
-                self.message_subscribe_users(
-                    user_ids=[sheet.employee_id.parent_id.user_id.id])
+        self._timesheet_subscribe_users()
         self.write({
             'state': 'confirm',
             'add_line_project_id': False,

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2018-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
@@ -127,18 +128,12 @@ class Sheet(models.Model):
         string='Select Project',
         help='If selected, the associated project is added '
              'to the timesheet sheet when clicked the button.',
-        states={
-            'draft': [('readonly', False)],
-        },
     )
     add_line_task_id = fields.Many2one(
         comodel_name='project.task',
         string='Select Task',
         help='If selected, the associated task is added '
              'to the timesheet sheet when clicked the button.',
-        states={
-            'draft': [('readonly', False)],
-        },
     )
     total_time = fields.Float(
         compute='_compute_total_time',
@@ -160,7 +155,7 @@ class Sheet(models.Model):
     @api.constrains('date_start', 'date_end', 'employee_id')
     def _check_sheet_date(self, forced_user_id=False):
         for sheet in self:
-            new_user_id = forced_user_id or sheet.user_id and sheet.user_id.id
+            new_user_id = forced_user_id or sheet.user_id.id
             if new_user_id:
                 self.env.cr.execute(
                     """
@@ -224,8 +219,7 @@ class Sheet(models.Model):
             if not rec.company_id:
                 continue
             for field in rec.timesheet_ids:
-                if rec.company_id and field.company_id and \
-                        rec.company_id != field.company_id:
+                if field.company_id and rec.company_id != field.company_id:
                     raise ValidationError(_(
                         'You cannot change the company, as this %s (%s) '
                         'is assigned to %s (%s).'
@@ -257,46 +251,51 @@ class Sheet(models.Model):
             dates = sheet._get_dates()
             if not dates:
                 continue
-            timesheets = sheet._get_timesheet_lines()
-            lines = self.env['hr_timesheet.sheet.line']
+            data_matrix = {}
+            projects = sheet.timesheet_ids.mapped('project_id')
             for date in dates:
-                for project in timesheets.mapped('project_id'):
-                    timesheet = timesheets.filtered(
-                        lambda x: (x.project_id == project))
-                    tasks = [task for task in timesheet.mapped('task_id')]
-                    if not timesheet or not all(
-                            [t.task_id for t in timesheet]):
+                for project in projects:
+                    project_timesheets = sheet.timesheet_ids.filtered(
+                        lambda x: x.project_id == project)
+                    tasks = [project_timesheets.mapped('task_id')]
+                    if not project_timesheets or not all(
+                            [t.task_id for t in project_timesheets]):
                         tasks += [self.env['project.task']]
                     for task in tasks:
-                        lines |= self.env['hr_timesheet.sheet.line'].create(
-                            sheet._get_default_sheet_line(
-                                date=date,
-                                project=project,
-                                task=task,
-                                timesheets=timesheet.filtered(
-                                    lambda t: date == t.date
-                                    and t.task_id.id == task.id),
-                            ))
-            sheet.line_ids = lines
+                        timesheets = project_timesheets.filtered(
+                            lambda t: date == t.date
+                            and t.task_id == task)
+                        unit_amount = sum(t.unit_amount for t in timesheets)
+                        data_matrix[(date, project, task)] = {
+                            'unit_amount': unit_amount,
+                            'timesheets': timesheets
+                        }
+            sheet.line_ids = sheet._create_data_matrix_lines(data_matrix)
 
-    def _get_timesheet_lines(self):
+    def _create_data_matrix_lines(self, data_matrix):
         self.ensure_one()
-        if self.state == 'draft':
-            domain = self._get_timesheet_sheet_lines_domain()
-            timesheets = self.env['account.analytic.line'].search(domain)
-        else:
-            timesheets = self.timesheet_ids
-        return timesheets
+        lines = self.env['hr_timesheet.sheet.line']
+        for item in data_matrix:
+            lines |= self.env['hr_timesheet.sheet.line'].create(
+                self._get_default_sheet_line(
+                    date=item[0],
+                    project=item[1],
+                    task=item[2],
+                    unit_amount=data_matrix[item]['unit_amount']
+                ))
+            self.clean_timesheets(data_matrix[item]['timesheets'])
+        return lines
 
-    @api.onchange('date_start', 'date_end', 'timesheet_ids')
-    def _onchange_dates_or_timesheets(self):
+    @api.onchange('date_start', 'date_end')
+    def _onchange_dates(self):
+        domain = self._get_timesheet_sheet_lines_domain()
+        timesheets = self.env['account.analytic.line'].search(domain)
+        self.link_timesheets_to_sheet(timesheets)
+        self.timesheet_ids = timesheets
+
+    @api.onchange('timesheet_ids')
+    def _onchange_timesheets(self):
         self._compute_line_ids()
-
-    @api.onchange('line_ids')
-    def _onchange_line_ids(self):
-        if self.state == 'draft' and not self.timesheet_ids and self.line_ids:
-            timesheets = self._get_timesheet_lines()
-            self.timesheet_ids = timesheets
 
     @api.onchange('add_line_project_id')
     def onchange_add_project_id(self):
@@ -380,21 +379,18 @@ class Sheet(models.Model):
                 _('Only an HR Officer or Manager can refuse sheets '
                   'or reset them to draft.'))
         self.write({'state': 'draft'})
-        return True
 
     @api.multi
     def action_timesheet_confirm(self):
         for sheet in self:
-            if sheet.employee_id and sheet.employee_id.parent_id \
-                    and sheet.employee_id.parent_id.user_id:
+            if sheet.employee_id.parent_id.user_id:
                 self.message_subscribe_users(
                     user_ids=[sheet.employee_id.parent_id.user_id.id])
-            if sheet.add_line_task_id:
-                sheet.add_line_task_id = False
-            if sheet.add_line_project_id:
-                sheet.add_line_project_id = False
-        self.write({'state': 'confirm'})
-        return True
+        self.write({
+            'state': 'confirm',
+            'add_line_project_id': False,
+            'add_line_task_id': False,
+        })
 
     @api.multi
     def action_timesheet_done(self):
@@ -416,7 +412,6 @@ class Sheet(models.Model):
                 rec.add_line(rec.add_line_project_id, rec.add_line_task_id)
                 rec.add_line_task_id = False
                 rec.add_line_project_id = False
-        return True
 
     def _get_date_name(self, date):
         return fields.Date.from_string(date).strftime("%a\n%b %d")
@@ -440,26 +435,19 @@ class Sheet(models.Model):
             name += ' - {}'.format(task.name)
         return name
 
-    def _get_default_sheet_line(self, date, project, task, timesheets=None):
+    def _get_default_sheet_line(self, date, project, task, unit_amount):
         name_y = self._get_line_name(project, task)
-        timesheet = self.clean_timesheets(timesheets)
         values = {
             'value_x': self._get_date_name(date),
             'value_y': name_y,
             'date': date,
             'project_id': project.id,
-            'task_id': task and task.id,
-            'count_timesheets': len(timesheet),
-            'unit_amount': 0.0,
+            'task_id': task.id,
+            'unit_amount': unit_amount,
         }
         if self.id:
             values.update({
                 'sheet_id': self.id,
-            })
-        if timesheet:
-            unit_amount = sum([t.unit_amount for t in timesheet])
-            values.update({
-                'unit_amount': unit_amount,
             })
         return values
 
@@ -469,8 +457,8 @@ class Sheet(models.Model):
             'name': empty_name,
             'employee_id': self.employee_id.id,
             'date': self.date_start,
-            'project_id': project and project.id,
-            'task_id': task and task.id,
+            'project_id': project.id,
+            'task_id': task.id,
             'sheet_id': self.id,
             'unit_amount': 0.0,
             'company_id': self.company_id.id,
@@ -488,10 +476,13 @@ class Sheet(models.Model):
                 self.timesheet_ids |= \
                     self.env['account.analytic.line'].create(values)
 
-    def clean_timesheets(self, timesheets):
+    def link_timesheets_to_sheet(self, timesheets):
+        self.ensure_one()
         if self.id and self.state == 'draft':
             for aal in timesheets.filtered(lambda a: not a.sheet_id):
                 aal.write({'sheet_id': self.id})
+
+    def clean_timesheets(self, timesheets):
         repeated = timesheets.filtered(lambda t: t.name == empty_name)
         if len(repeated) > 1 and self.id:
             return repeated.merge_timesheets()
@@ -501,16 +492,10 @@ class Sheet(models.Model):
         for name in self.line_ids.mapped('value_y'):
             row = self.line_ids.filtered(lambda l: l.value_y == name)
             if row:
-                task = row[0].task_id and row[0].task_id.id or False
-                ts_row = self.env['account.analytic.line'].search([
-                    ('project_id', '=', row[0].project_id.id),
-                    ('task_id', '=', task),
-                    ('date', '<=', self.date_end),
-                    ('date', '>=', self.date_start),
-                    ('employee_id', '=', self.employee_id.id),
-                    ('sheet_id', '=', self.id),
-                    ('company_id', '=', self.company_id.id),
-                ])
+                ts_row = self.timesheet_ids.filtered(
+                    lambda x: x.project_id.id == row[0].project_id.id
+                    and x.task_id.id == row[0].task_id.id
+                )
                 if delete_empty_rows and self.add_line_project_id:
                     check = any([l.unit_amount for l in row])
                 else:
@@ -564,9 +549,6 @@ class SheetLine(models.TransientModel):
         string="Quantity",
         default=0.0,
     )
-    count_timesheets = fields.Integer(
-        default=0,
-    )
 
     @api.onchange('unit_amount')
     def onchange_unit_amount(self):
@@ -575,93 +557,45 @@ class SheetLine(models.TransientModel):
         If yes, it does several comparisons to see if the unit_amount of
         the timesheets should be updated accordingly."""
         self.ensure_one()
-        if self.unit_amount < 0.0:
-            self.write({'unit_amount': 0.0})
-        if self.unit_amount and not self.count_timesheets:
-            self._create_timesheet(self.unit_amount)
-        elif self.count_timesheets:
-            task = self.task_id and self.task_id.id or False
-            timesheets = self.env['account.analytic.line'].search([
-                ('project_id', '=', self.project_id.id),
-                ('task_id', '=', task),
-                ('date', '=', self.date),
-                ('employee_id', '=', self.sheet_id.employee_id.id),
-                ('sheet_id', '=', self.sheet_id.id),
-                ('company_id', '=', self.sheet_id.company_id.id),
-            ])
-            if len(timesheets) != self.count_timesheets:
-                _logger.info('Found timesheets %s, expected %s',
-                             len(timesheets), self.count_timesheets)
-                self.count_timesheets = len(timesheets)
-            if not self.unit_amount:
-                new_ts = timesheets.filtered(lambda t: t.name == empty_name)
-                other_ts = timesheets.filtered(lambda t: t.name != empty_name)
-                if new_ts:
-                    new_ts.unlink()
-                for timesheet in other_ts:
-                    timesheet.write({'unit_amount': 0.0})
-                self.count_timesheets = len(other_ts)
-            else:
-                if self.count_timesheets == 1:
-                    timesheets.write({'unit_amount': self.unit_amount})
-                elif self.count_timesheets > 1:
-                    amount = sum([t.unit_amount for t in timesheets])
-                    new_ts = timesheets.filtered(
-                        lambda t: t.name == empty_name)
-                    other_ts = timesheets.filtered(
-                        lambda t: t.name != empty_name)
-                    diff_amount = self.unit_amount - amount
-                    if new_ts:
-                        if len(new_ts) > 1:
-                            new_ts = new_ts.merge_timesheets()
-                            self.count_timesheets = len(
-                                self.sheet_id.timesheet_ids)
-                        if new_ts.unit_amount + diff_amount >= 0.0:
-                            if diff_amount != 0.0:
-                                new_ts.unit_amount += diff_amount
-                            if not new_ts.unit_amount:
-                                new_ts.unlink()
-                                self.count_timesheets -= 1
-                        else:
-                            diff_amount += new_ts.unit_amount
-                            new_ts.write({'unit_amount': 0.0})
-                            new_ts.unlink()
-                            self.count_timesheets -= 1
-                            self._diff_amount_timesheets(diff_amount, other_ts)
-                    else:
-                        if diff_amount > 0.0:
-                            self._create_timesheet(diff_amount)
-                        else:
-                            self._diff_amount_timesheets(diff_amount, other_ts)
-                else:
-                    raise ValidationError(
-                        _('Error code: Cannot have 0 timesheets.'))
 
-    def _create_timesheet(self, amount):
-        values = self._line_to_timesheet(amount)
-        if self.env['account.analytic.line'].create(values):
-            self.count_timesheets += 1
-
-    @api.model
-    def _diff_amount_timesheets(self, diff_amount, timesheets):
-        for timesheet in timesheets:
-            if timesheet.unit_amount + diff_amount >= 0.0:
-                if diff_amount != 0.0:
-                    timesheet.unit_amount += diff_amount
-                break
-            else:
-                diff_amount += timesheet.unit_amount
-                timesheet.write({'unit_amount': 0.0})
+        sheet = self.sheet_id
+        if not sheet:
+            model = self.env.context.get('params', {}).get('model', '')
+            obj_id = self.env.context.get('params', {}).get('id')
+            if model == 'hr_timesheet.sheet' and isinstance(obj_id, int):
+                sheet = self.env['hr_timesheet.sheet'].browse(obj_id)
+        if not sheet:
+            return {'warning': {
+                'title': _("Warning"),
+                'message': _("Save the Timesheet Sheet first.")
+            }}
+        timesheets = sheet.timesheet_ids.filtered(
+            lambda t: t.date == self.date
+            and t.project_id.id == self.project_id.id
+            and t.task_id.id == self.task_id.id
+        )
+        new_ts = timesheets.filtered(lambda t: t.name == empty_name)
+        amount = sum(t.unit_amount for t in timesheets)
+        diff_amount = self.unit_amount - amount
+        if not diff_amount:
+            return
+        if new_ts:
+            if len(new_ts) > 1:
+                new_ts = new_ts.merge_timesheets()
+            unit_amount = new_ts.unit_amount + diff_amount
+            new_ts.write({'unit_amount': unit_amount})
+        else:
+            new_ts_values = self._line_to_timesheet(diff_amount)
+            self.env['account.analytic.line'].create(new_ts_values)
 
     @api.model
     def _line_to_timesheet(self, amount):
-        task = self.task_id.id if self.task_id else False
         return {
             'name': empty_name,
             'employee_id': self.sheet_id.employee_id.id,
             'date': self.date,
             'project_id': self.project_id.id,
-            'task_id': task,
+            'task_id': self.task_id.id,
             'sheet_id': self.sheet_id.id,
             'unit_amount': amount,
             'company_id': self.sheet_id.company_id.id,

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -96,11 +96,11 @@ class TestHrTimesheetSheet(TransactionCase):
 
     def test_1(self):
         sheet = self.sheet_model.sudo(self.user).create({
-            'employee_id': self.employee.id,
             'company_id': self.user.company_id.id,
         })
         self.assertEqual(len(sheet.timesheet_ids), 0)
         self.assertEqual(len(sheet.line_ids), 0)
+        self.assertTrue(sheet.employee_id)
 
         sheet.add_line_project_id = self.project_1
         sheet.onchange_add_project_id()

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2018-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0
 
 from odoo import fields
@@ -104,13 +105,13 @@ class TestHrTimesheetSheet(TransactionCase):
         sheet.add_line_project_id = self.project_1
         sheet.onchange_add_project_id()
         sheet.sudo(self.user).button_add_line()
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertEqual(len(sheet.line_ids), 7)
 
         sheet.date_end = fields.Date.to_string(
             fields.Date.from_string(sheet.date_end) + relativedelta(days=1))
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 0)
         self.assertEqual(len(sheet.line_ids), 0)
 
@@ -131,7 +132,7 @@ class TestHrTimesheetSheet(TransactionCase):
         sheet.add_line_project_id = self.project_1
         sheet.onchange_add_project_id()
         sheet.sudo(self.user).button_add_line()
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         sheet.onchange_add_project_id()
         self.assertEqual(sheet.add_line_project_id.id, False)
         self.assertEqual(len(sheet.line_ids), 7)
@@ -140,19 +141,17 @@ class TestHrTimesheetSheet(TransactionCase):
 
         line = sheet.line_ids.filtered(lambda l: l.date != timesheet.date)[0]
         self.assertEqual(line.unit_amount, 0.0)
-        self.assertEqual(line.count_timesheets, 0)
         line._cache.update(
             line._convert_to_cache(
                 {'unit_amount': 1.0}, update=True))
         line.onchange_unit_amount()
         self.assertEqual(line.unit_amount, 1.0)
-        self.assertEqual(line.count_timesheets, 1)
         self.assertEqual(len(sheet.timesheet_ids), 2)
 
         sheet.add_line_project_id = self.project_2
         sheet.onchange_add_project_id()
         sheet.sudo(self.user).button_add_line()
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 2)
         self.assertNotIn(timesheet.id, sheet.timesheet_ids.ids)
         self.assertEqual(len(sheet.line_ids), 14)
@@ -197,12 +196,12 @@ class TestHrTimesheetSheet(TransactionCase):
             'date_end': self.sheet_model._default_date_end(),
             'state': 'draft',
         })
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_dates()
         self.assertEqual(len(sheet.line_ids), 7)
-        self.assertEqual(len(sheet.timesheet_ids), 0)
+        self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertTrue(self.aal_model.search([('id', '=', timesheet.id)]))
 
-        sheet._onchange_line_ids()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 1)
 
@@ -239,6 +238,8 @@ class TestHrTimesheetSheet(TransactionCase):
             'employee_id': self.employee.id,
             'company_id': self.user.company_id.id,
         })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 2)
 
@@ -249,11 +250,10 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(timesheet_3.unit_amount, 0.0)
 
         line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
-        self.assertEqual(line.count_timesheets, 1)
         self.assertEqual(line.unit_amount, 1.0)
         line.unit_amount = 0.0
         line.onchange_unit_amount()
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertFalse(self.aal_model.search(
             [('id', '=', timesheet_1_or_2.id)]))
@@ -263,7 +263,7 @@ class TestHrTimesheetSheet(TransactionCase):
         sheet.onchange_add_project_id()
         sheet.add_line_task_id = self.task_2
         sheet.sudo(self.user).button_add_line()
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertFalse(self.aal_model.search(
@@ -286,10 +286,11 @@ class TestHrTimesheetSheet(TransactionCase):
             'employee_id': self.employee.id,
             'company_id': self.user.company_id.id,
         })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 2)
         line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
-        self.assertEqual(line.count_timesheets, 2)
         self.assertEqual(line.unit_amount, 4.0)
 
         timesheet_2.name = '/'
@@ -297,7 +298,7 @@ class TestHrTimesheetSheet(TransactionCase):
             line._convert_to_cache(
                 {'unit_amount': 3.0}, update=True))
         line.onchange_unit_amount()
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertEqual(sheet.timesheet_ids[0].unit_amount, 3.0)
 
@@ -310,9 +311,8 @@ class TestHrTimesheetSheet(TransactionCase):
             line._convert_to_cache(
                 {'unit_amount': 4.0}, update=True))
         line.onchange_unit_amount()
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 1)
-        self.assertEqual(line.count_timesheets, 1)
         self.assertEqual(sheet.timesheet_ids[0].unit_amount, 4.0)
         self.assertEqual(timesheet_1_or_2.unit_amount, 4.0)
 
@@ -320,9 +320,9 @@ class TestHrTimesheetSheet(TransactionCase):
             line._convert_to_cache(
                 {'unit_amount': -1.0}, update=True))
         line.onchange_unit_amount()
-        sheet._onchange_dates_or_timesheets()
-        self.assertEqual(len(sheet.line_ids), 0)
-        self.assertEqual(len(sheet.timesheet_ids), 0)
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.line_ids), 7)
+        self.assertEqual(len(sheet.timesheet_ids), 1)
 
     def test_6(self):
         timesheet_1 = self.aal_model.create({
@@ -359,10 +359,11 @@ class TestHrTimesheetSheet(TransactionCase):
             'employee_id': self.employee.id,
             'company_id': self.user.company_id.id,
         })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 5)
         line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
-        self.assertEqual(line.count_timesheets, 5)
         self.assertEqual(line.unit_amount, 10.0)
 
         timesheet_2.name = '/'
@@ -370,9 +371,8 @@ class TestHrTimesheetSheet(TransactionCase):
             line._convert_to_cache(
                 {'unit_amount': 6.0}, update=True))
         line.onchange_unit_amount()
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 3)
-        self.assertEqual(line.count_timesheets, 3)
 
         timesheet_1_or_2 = self.aal_model.search(
             [('id', 'in', [timesheet_1.id, timesheet_2.id])])
@@ -382,9 +382,9 @@ class TestHrTimesheetSheet(TransactionCase):
             line._convert_to_cache(
                 {'unit_amount': 3.0}, update=True))
         line.onchange_unit_amount()
-        sheet._onchange_dates_or_timesheets()
-        self.assertEqual(len(sheet.timesheet_ids), 3)
-        self.assertEqual(line.count_timesheets, 3)
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.timesheet_ids), 4)
+        self.assertEqual(line.unit_amount, 3.0)
 
         timesheet_3_4_and_5 = self.aal_model.search(
             [('id', 'in', [timesheet_3.id, timesheet_4.id, timesheet_5.id])])
@@ -396,20 +396,19 @@ class TestHrTimesheetSheet(TransactionCase):
             'employee_id': self.employee.id,
             'unit_amount': 2.0,
         })
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 4)
         line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
-        self.assertEqual(line.count_timesheets, 4)
+        self.assertEqual(len(line), 1)
         self.assertEqual(line.unit_amount, 5.0)
 
         line._cache.update(
             line._convert_to_cache(
                 {'unit_amount': 1.0}, update=True))
         line.onchange_unit_amount()
-        sheet._onchange_dates_or_timesheets()
-        self.assertEqual(len(sheet.timesheet_ids), 3)
-        self.assertEqual(line.count_timesheets, 3)
-        self.assertFalse(self.aal_model.search([('id', '=', timesheet_6.id)]))
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.timesheet_ids), 4)
+        self.assertTrue(self.aal_model.search([('id', '=', timesheet_6.id)]))
 
     def test_7(self):
         sheet = self.sheet_model.sudo(self.user).new({
@@ -419,7 +418,7 @@ class TestHrTimesheetSheet(TransactionCase):
             'date_end': self.sheet_model._default_date_start(),
             'state': 'draft',
         })
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.line_ids), 0)
         self.assertEqual(len(sheet.timesheet_ids), 0)
         with self.assertRaises(ValidationError):
@@ -485,7 +484,7 @@ class TestHrTimesheetSheet(TransactionCase):
         sheet.add_line_project_id = self.project_1
         sheet.onchange_add_project_id()
         sheet.sudo(self.user).button_add_line()
-        sheet._onchange_dates_or_timesheets()
+        sheet._onchange_timesheets()
         sheet.onchange_add_project_id()
         self.assertEqual(len(sheet.timesheet_ids), 1)
 
@@ -517,3 +516,94 @@ class TestHrTimesheetSheet(TransactionCase):
                                           "Sunday")
 
         self.assertEqual(weekday_to, 5, "The timesheet should end on Saturday")
+
+    def test_11_onchange_unit_amount(self):
+        """Test onchange unit_amount for line without sheet_id."""
+        self.aal_model.create({
+            'name': 'test1',
+            'project_id': self.project_1.id,
+            'employee_id': self.employee.id,
+            'unit_amount': 2.0,
+            'date': self.sheet_model._default_date_start(),
+        })
+        self.aal_model.create({
+            'name': 'test2',
+            'project_id': self.project_1.id,
+            'employee_id': self.employee.id,
+            'unit_amount': 2.0,
+            'date': self.sheet_model._default_date_start(),
+        })
+        sheet = self.sheet_model.sudo(self.user).create({
+            'employee_id': self.employee.id,
+            'company_id': self.user.company_id.id,
+            'department_id': self.department.id,
+            'date_start': self.sheet_model._default_date_start(),
+            'date_end': self.sheet_model._default_date_end(),
+            'state': 'draft',
+        })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.timesheet_ids), 2)
+        self.assertEqual(len(sheet.line_ids), 7)
+
+        for line in sheet.line_ids:
+            if line.unit_amount:
+                line.sheet_id = False
+                unit_amount = line.unit_amount
+                line.write({'unit_amount': unit_amount + 1.0})
+                res_onchange = line.with_context(
+                    params={'model': 'hr_timesheet.sheet', 'id': sheet.id}
+                ).onchange_unit_amount()
+                self.assertFalse(res_onchange)
+                self.assertEqual(line.unit_amount, unit_amount + 1.0)
+
+        sheet._onchange_dates()
+        self.assertEqual(len(sheet.timesheet_ids), 3)
+        self.assertEqual(len(sheet.line_ids), 7)
+
+        new_timesheet = sheet.timesheet_ids.filtered(lambda t: t.name == '/')
+        self.assertEqual(len(new_timesheet), 1)
+        self.assertEqual(new_timesheet.unit_amount, 1.0)
+
+        for line in sheet.line_ids:
+            if line.unit_amount:
+                line.sheet_id = False
+                unit_amount = line.unit_amount
+                line.write({'unit_amount': unit_amount + 1.0})
+                res_onchange = line.onchange_unit_amount()
+                warning = res_onchange.get('warning')
+                self.assertTrue(warning)
+                message = warning.get('message')
+                self.assertTrue(message)
+
+    def test_12_creating_sheet(self):
+        """Test onchange unit_amount for line without sheet_id."""
+        self.aal_model.create({
+            'name': 'test1',
+            'project_id': self.project_1.id,
+            'employee_id': self.employee.id,
+            'unit_amount': 2.0,
+            'date': self.sheet_model._default_date_start(),
+        })
+        sheet = self.sheet_model.sudo(self.user).create({
+            'employee_id': self.employee.id,
+            'company_id': self.user.company_id.id,
+            'department_id': self.department.id,
+            'date_start': self.sheet_model._default_date_start(),
+            'date_end': self.sheet_model._default_date_end(),
+        })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.timesheet_ids), 1)
+        self.assertEqual(len(sheet.line_ids), 7)
+
+        line = sheet.line_ids.filtered(lambda l: l.unit_amount)
+        self.assertEqual(len(line), 1)
+        self.assertEqual(line.unit_amount, 2.0)
+
+        unit_amount = line.unit_amount
+        line.write({'unit_amount': unit_amount})
+        line.onchange_unit_amount()
+        self.assertEqual(line.unit_amount, 2.0)
+        self.assertEqual(len(sheet.timesheet_ids), 1)
+        self.assertEqual(len(sheet.line_ids), 7)

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <tree decoration-info="state == 'draft'" decoration-muted="state == 'done'" decoration-bf="message_needaction == True" string="Timesheet Sheets">
                 <field name="employee_id"/>
+                <field name="display_name" string="Period"/>
                 <field name="date_start"/>
                 <field name="date_end"/>
                 <field name="department_id" invisible="1"/>

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -48,7 +48,7 @@
                     <notebook>
                         <page string="Summary">
                             <group name="Sheet">
-                                <field name="line_ids" nolabel="1" attrs="{'readonly': [('state', '!=', 'draft')]}"
+                                <field name="line_ids" nolabel="1" attrs="{'readonly': [('state', 'not in', ['new', 'draft'])]}"
                                        widget="x2many_2d_matrix"
                                        field_x_axis="value_x"
                                        field_y_axis="value_y"
@@ -68,7 +68,7 @@
                                         <field name="task_id"/>
                                     </tree>
                                 </field>
-                                <group class="oe_edit_only" attrs="{'invisible': [('state', '!=', 'draft')]}">
+                                <group class="oe_edit_only" attrs="{'invisible': [('state', 'not in', ['new', 'draft'])]}">
                                     <field name="add_line_project_id" domain="[('company_id', '=', company_id), ('allow_timesheets', '=', True)]"/>
                                     <field name="add_line_task_id" attrs="{'invisible': [('add_line_project_id', '=', False)]}"
                                            context="{'default_project_id': add_line_project_id}"/>

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -43,7 +43,7 @@
                             <div style="display: inline;"><field name="date_start" class="oe_inline"/> to <field name="date_end" class="oe_inline"/></div>
                             <field name="name" invisible="1"/>
                             <field name="department_id" invisible="1"/>
-                            <field name="company_id" groups="base.group_multi_company" readonly="1"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                     </group>
                     <notebook>

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -66,7 +66,6 @@
                                         <field name="date"/>
                                         <field name="project_id"/>
                                         <field name="task_id"/>
-                                        <field name="count_timesheets"/>
                                     </tree>
                                 </field>
                                 <group class="oe_edit_only" attrs="{'invisible': [('state', '!=', 'draft')]}">
@@ -82,7 +81,7 @@
                             </group>
                         </page>
                         <page string="Details">
-                            <field context="{'employee_id': employee_id, 'user_id':user_id, 'timesheet_date_start': date_start, 'timesheet_date_end': date_end}" name="timesheet_ids" nolabel="1">
+                            <field name="timesheet_ids" nolabel="1">
                                 <tree editable="bottom" string="Timesheet Activities">
                                     <field name="date"/>
                                     <field name="project_id" required="1"/>


### PR DESCRIPTION
This PR fixes the amount calculation issues (see https://github.com/OCA/hr-timesheet/issues/206) regarding the decrease of the amount of hours from the summary tab.
The idea is that decreasing the amount from the summary tab should not directly decrease the amounts of time for existing projects and/or tasks, to avoid potential loose of relevant information. In case it's needed, it's up to the end user to manually adjust the amounts or merge lines in the details tab.
This is basically achieved by removing the `def _diff_amount_timesheets()` method.

The proposed solution also causes a code reduction (simplified code) including the following:

 - Removed `count_timesheets` field
 - Simplified code for `def onchange_unit_amount()`
 - Makes use of field `sheet.timesheet_ids` in place of `self.env['account.analytic.line'].search()`

This PR implicitly allows negative amounts: [two lines](https://github.com/OCA/hr-timesheet/blob/11.0/hr_timesheet_sheet/models/hr_timesheet_sheet.py#L578-L579) are removed from `def onchange_unit_amount()`, the same way as it is done in https://github.com/OCA/hr-timesheet/pull/201.

This PR also fixes method `def _default_employee()` in a multicompany environment, filtering the default employee by company.

Fixes #198 

Fixes #209