### PR TITLE
[11.0][FIX] hr_timesheet_sheet: fix constraint for company_id in lines

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.3.2',
+    'version': '11.0.1.3.3',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/models/__init__.py
+++ b/hr_timesheet_sheet/models/__init__.py
@@ -1,3 +1,4 @@
+from . import account_analytic_account
 from . import account_analytic_line
 from . import hr_department
 from . import hr_employee

--- a/hr_timesheet_sheet/models/account_analytic_account.py
+++ b/hr_timesheet_sheet/models/account_analytic_account.py
@@ -1,0 +1,21 @@
+# Copyright 2019 Onestein (<https://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = 'account.analytic.account'
+
+    @api.constrains('company_id')
+    def _check_timesheet_sheet_company_id(self):
+        for rec in self.sudo():
+            sheets = rec.line_ids.mapped('sheet_id').filtered(
+                lambda s: s.company_id and s.company_id != rec.company_id)
+            if sheets:
+                raise ValidationError(_(
+                    'You cannot change the company, as this %s (%s) '
+                    'is assigned to %s (%s).'
+                ) % (rec._name, rec.display_name,
+                     sheets[0]._name, sheets[0].display_name))

--- a/hr_timesheet_sheet/models/account_analytic_line.py
+++ b/hr_timesheet_sheet/models/account_analytic_line.py
@@ -70,6 +70,7 @@ class AccountAnalyticLine(models.Model):
             'user_id',
             'employee_id',
             'department_id',
+            'company_id',
             'task_id',
             'project_id',
             'sheet_id',

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -222,19 +222,6 @@ class Sheet(models.Model):
                     _('The Company in the Timesheet Sheet and in '
                       'the Task must be the same.'))
 
-    @api.constrains('company_id')
-    def _check_company_id(self):
-        for rec in self.sudo():
-            if not rec.company_id:
-                continue
-            for field in rec.timesheet_ids:
-                if field.company_id and rec.company_id != field.company_id:
-                    raise ValidationError(_(
-                        'You cannot change the company, as this %s (%s) '
-                        'is assigned to %s (%s).'
-                    ) % (rec._name, rec.display_name,
-                         field._name, field.display_name))
-
     @api.onchange('employee_id')
     def _onchange_employee_id(self):
         if self.employee_id:

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -608,3 +608,29 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(line.unit_amount, 2.0)
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertEqual(len(sheet.line_ids), 7)
+
+    def test_13(self):
+        """Test company constraint in Account Analytic Account."""
+        self.aal_model.create({
+            'name': 'test1',
+            'project_id': self.project_1.id,
+            'employee_id': self.employee.id,
+            'company_id': self.company.id,
+            'unit_amount': 2.0,
+            'date': self.sheet_model._default_date_start(),
+        })
+        self.assertNotEqual(self.company, self.company_2)
+        sheet = self.sheet_model.sudo(self.user).create({
+            'employee_id': self.employee.id,
+            'department_id': self.department.id,
+        })
+        self.assertEqual(sheet.company_id, self.company)
+        sheet._onchange_dates()
+        self.assertEqual(len(sheet.timesheet_ids), 1)
+        self.assertEqual(sheet.timesheet_ids.company_id, self.company)
+
+        analytic_account = sheet.timesheet_ids.account_id
+        self.assertEqual(analytic_account.company_id, self.company)
+
+        with self.assertRaises(ValidationError):
+            analytic_account.company_id = self.company_2


### PR DESCRIPTION
This PR fixes the following issue:

1. Be sure that admin user belongs to company: YourCompany.
2. Create CompanyB.
3. Create UserB, belonging to CompanyB.
4. Create EmployeeB, belonging to CompanyB and linked to UserB.
5. Login as UserB and create a new timesheet sheet. Add one line (eg.: description="timesheetB"). Save.
5. Login as admin and change the company of the Analytic Account related to the timesheet "timesheetB". Save.

Current behavior: the system allows to change the company of the Analytic Account.
Since the `company_id` of the timesheet sheet lines (account.analytic.line) is a [related field](https://github.com/odoo/odoo/blob/11.0/addons/analytic/models/analytic_account.py#L110), there is an inconsistency with the company of the timesheet sheet.

Espected behavior: an error should be raised.