### PR TITLE
[11.0][FIX] hr_timesheet_sheet: case of employee's company not set

### DIFF
--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -634,3 +634,38 @@ class TestHrTimesheetSheet(TransactionCase):
 
         with self.assertRaises(ValidationError):
             analytic_account.company_id = self.company_2
+
+    def test_14(self):
+        department = self.department_model.create({
+            'name': "Department test",
+            'company_id': False,
+        })
+        new_employee = self.employee_model.create({
+            'name': "Test User",
+            'user_id': self.user.id,
+            'company_id': False,
+            'department_id': department.id,
+        })
+        self.assertFalse(new_employee.company_id)
+        sheet_no_department = self.sheet_model.sudo(self.user).create({
+            'employee_id': new_employee.id,
+            'department_id': False,
+            'date_start': self.sheet_model._default_date_start(),
+            'date_end': self.sheet_model._default_date_end(),
+        })
+        self.assertFalse(sheet_no_department.department_id)
+        sheet_no_department._onchange_employee_id()
+        self.assertTrue(sheet_no_department.department_id)
+        self.assertEqual(sheet_no_department.department_id, department)
+        self.assertTrue(sheet_no_department.company_id)
+
+        sheet_no_department.unlink()
+        sheet_no_employee = self.sheet_model.sudo(self.user).create({
+            'date_start': self.sheet_model._default_date_start(),
+            'date_end': self.sheet_model._default_date_end(),
+        })
+        self.assertTrue(sheet_no_employee.employee_id)
+        self.assertFalse(sheet_no_employee.department_id)
+        sheet_no_employee._onchange_employee_id()
+        self.assertFalse(sheet_no_employee.department_id)
+        self.assertTrue(sheet_no_employee.company_id)

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -43,7 +43,7 @@
                             <div style="display: inline;"><field name="date_start" class="oe_inline"/> to <field name="date_end" class="oe_inline"/></div>
                             <field name="name" invisible="1"/>
                             <field name="department_id" invisible="1"/>
-                            <field name="company_id" groups="base.group_multi_company"/>
+                            <field name="company_id" groups="base.group_multi_company" force_save="1"/>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
This PR fixes the following:

Set Company=False for employee Pieter Parker and create a timesheet sheet for Pieter Parker.
Error is raised:
```
Error while validating constraint

operator does not exist: integer = boolean
LINE 6: AND company_id=false
^
HINT: No operator matches the given name and argument type(s). You might need to add explicit type casts.
```

In this proposed solution, if the company=False for an employee, it takes the company of the department. If the company of the department is also not set, it takes the company of the user.

The company_id of the timesheet sheet is now a required field, since the module doesn't work fine (not yet) when company_id is empty.

