### PR TITLE
[11.0][FIX] hr_timesheet_sheet: submit to manager in multicompany

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.3.2',
+    'version': '11.0.1.3.3',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -373,7 +373,7 @@ class Sheet(models.Model):
     def _timesheet_subscribe_users(self):
         for sheet in self:
             if sheet.employee_id.parent_id.user_id:
-                self.message_subscribe_users(
+                self.sudo().message_subscribe_users(
                     user_ids=[sheet.employee_id.parent_id.user_id.id])
 
     @api.multi

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -62,9 +62,16 @@ class TestHrTimesheetSheet(TransactionCase):
              'company_ids': [(4, self.company_2.id)],
              })
 
+        employee_manager = self.employee_model.create({
+            'name': "Test Manager",
+            'user_id': self.user_2.id,
+            'company_id': self.user.company_id.id,
+        })
+
         self.employee = self.employee_model.create({
             'name': "Test User",
             'user_id': self.user.id,
+            'parent_id': employee_manager.id,
             'company_id': self.user.company_id.id,
         })
 


### PR DESCRIPTION
This PR fixes the following error, already occurred long time ago in our production environment:

Create _UserA_ of _CompanyA_. Groups: Timesheets Manager. Allowed companies: _CompanyA_ and _CompanyB_. Create _EmployeeA_ of _CompanyA_ and Related User: _UserA_.


Create _UserB_ of _CompanyB_. Groups: Timesheets User. Create _EmployeeB_ of _CompanyB_ and Related User: _UserB_.

For _EmployeeB_ set Manager=_EmployeeA_


_UserA_ logs in on _CompanyA_. So now _CompanyA_ is the value set for `company_id` of _UserA_.


Login as _UserB_ and create a timesheet sheet. Save.
Click on "Submit to Manager".

Submit fails with following error:

```
The requested operation cannot be completed due to security restrictions. Please contact your system administrator.

(Document type: res.users, Operation: read) 
```

The cause is this block of code, trying to read the user of a different company:

```python
            if sheet.employee_id.parent_id.user_id:
                self.message_subscribe_users(
                    user_ids=[sheet.employee_id.parent_id.user_id.id])
```
