### PR TITLE
[11.0][FIX] hr_timesheet_sheet: adding lines of other employees

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.3.1',
+    'version': '11.0.1.3.2',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -82,7 +82,7 @@
                             </group>
                         </page>
                         <page string="Details">
-                            <field name="timesheet_ids" nolabel="1">
+                            <field name="timesheet_ids" nolabel="1" context="{'user_id': user_id}">
                                 <tree editable="bottom" string="Timesheet Activities">
                                     <field name="date"/>
                                     <field name="project_id" required="1"/>


### PR DESCRIPTION
This PR fixes the following:

Login as admin. Create a new timesheet sheet and set Employee="Demo User".
Save. The timesheet sheet of "Demo User" is created.

Edit. Add a new line. Save.

Result:
the new line is not in the timesheet sheet of "Demo User".
The new line is instead in the timesheet sheet of "Pieter Parker".

Expected: the new line should be in the timesheet sheet of "Demo User"
