### PR TITLE
[11.0][FIX] hr_timesheet_sheet: company on projects and employees

### DIFF
--- a/hr_timesheet_sheet/models/account_analytic_line.py
+++ b/hr_timesheet_sheet/models/account_analytic_line.py
@@ -28,9 +28,18 @@ class AccountAnalyticLine(models.Model):
             if timesheet.sheet_id != sheet:
                 timesheet.sheet_id = sheet
 
+    def _check_sheet_company_id(self, sheet_id):
+        self.ensure_one()
+        sheet = self.env['hr_timesheet.sheet'].browse(sheet_id)
+        if sheet.company_id and sheet.company_id != self.company_id:
+            raise UserError(
+                _('You cannot create a timesheet of a different company '
+                  'than the one of the timesheet sheet.'))
+
     @api.model
     def create(self, values):
         res = super(AccountAnalyticLine, self).create(values)
+        res._check_sheet_company_id(values.get('sheet_id'))
         res._compute_sheet()
         return res
 


### PR DESCRIPTION
This PR fixes the following:

Create a company: _CompanyB_.

Configure the admin user with:

- Groups: "Timesheets Manager"
- Allowed companies: _YourCompany_ and _CompanyB_.


Create _UserB_ of _CompanyB_:

- Groups: "Timesheets User".
- Create _EmployeeB_ of _CompanyB_ and Related User: _UserB_.


Login as admin and create a timesheet sheet for _UserB_.
Add a new line with following project: "Data Import/Export Plugin".
Save.


**Issue 1**
The new line is not displayed in the timesheet sheet (not ok).

**Issue 2**
Go to "All Timesheets": open the new line just created. 
You can notice that Employee="_EmployeeB_" and Company="_YourCompany_" (not ok).
I would expect that _EmployeeB_ can only create timesheets for _CompanyB_.

**Issue 3**
Project "Data Import/Export Plugin" belongs to _YourCompany_.
This is inconsistent with the selected employee "_EmployeeB_" who belongs to _CompanyB_ only (not ok).
I would expect that an error would be raised when creating that inconsistent timesheet.


This PR depends on:

- [x] https://github.com/OCA/hr-timesheet/pull/225

