### PR TITLE
[12.0][FIX] hr_timesheet_sheet: subscribe user when confirm

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.1.1',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -377,7 +377,7 @@ class Sheet(models.Model):
         return super().unlink()
 
     def _timesheet_subscribe_users(self):
-        for sheet in self:
+        for sheet in self.sudo():
             manager = sheet.employee_id.parent_id.user_id.partner_id
             if manager:
                 self.message_subscribe(partner_ids=manager.ids)

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -378,9 +378,9 @@ class Sheet(models.Model):
 
     def _timesheet_subscribe_users(self):
         for sheet in self:
-            if sheet.employee_id.parent_id.user_id:
-                self.message_subscribe_users(
-                    user_ids=[sheet.employee_id.parent_id.user_id.id])
+            manager = sheet.employee_id.parent_id.user_id.partner_id
+            if manager:
+                self.message_subscribe(partner_ids=manager.ids)
 
     @api.multi
     def action_timesheet_draft(self):

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -62,9 +62,16 @@ class TestHrTimesheetSheet(TransactionCase):
              'company_ids': [(4, self.company_2.id)],
              })
 
+        employee_manager = self.employee_model.create({
+            'name': "Test Manager",
+            'user_id': self.user_2.id,
+            'company_id': self.user.company_id.id,
+        })
+
         self.employee = self.employee_model.create({
             'name': "Test User",
             'user_id': self.user.id,
+            'parent_id': employee_manager.id,
             'company_id': self.user.company_id.id,
         })
 


### PR DESCRIPTION
This PR fixes the following:

Set a manager for an employee.
Confirm the timesheet of the employee.

Result:
`AttributeError: 'hr_timesheet.sheet' object has no attribute 'message_subscribe_users'`


This PR also includes the porting of https://github.com/OCA/hr-timesheet/pull/224 to V12.