### PR TITLE
[FIX] hr_timesheet_sheet: fix tests

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.3.0',
+    'version': '11.0.1.3.1',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -332,25 +332,25 @@ class TestHrTimesheetSheet(TransactionCase):
             'unit_amount': 2.0,
         })
         timesheet_2 = self.aal_model.create({
-            'name': 'w',
+            'name': 'v',
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
             'unit_amount': 2.0,
         })
         timesheet_3 = self.aal_model.create({
-            'name': 'x',
+            'name': 'w',
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
             'unit_amount': 2.0,
         })
         timesheet_4 = self.aal_model.create({
-            'name': 'y',
+            'name': 'x',
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
             'unit_amount': 2.0,
         })
         timesheet_5 = self.aal_model.create({
-            'name': 'z',
+            'name': 'y',
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
             'unit_amount': 2.0,
@@ -391,11 +391,12 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(len(timesheet_3_4_and_5), 3)
 
         timesheet_6 = self.aal_model.create({
-            'name': '/',
+            'name': 'z',
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
             'unit_amount': 2.0,
         })
+        timesheet_5.name = '/'
         sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 4)
         line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)


### PR DESCRIPTION
As timesheets are merged by position as you can see here:

https://github.com/OCA/hr-timesheet/blob/11.0/hr_timesheet_sheet/models/account_analytic_line.py#L97

It's necessary not to create a timesheet in tests without name the last one, because then, sometimes the tests fail because we are unlinking the last one that is checked later in test, here:

https://github.com/OCA/hr-timesheet/blob/11.0/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py#L411 

cc @Tecnativa

This update does not change the purpose of the tests. 