### PR TITLE
[11.0][FIX/IMP] hr_timesheet_sheet

### DIFF
--- a/hr_timesheet_sheet/README.rst
+++ b/hr_timesheet_sheet/README.rst
@@ -29,6 +29,14 @@ If you want other default ranges different from weekly, you need to go:
   and select in **Timesheet Sheet Range** the default range you want.
 * When you have a weekly range you can also specify the **Week Start Day**.
 
+Usage
+=====
+
+If you modify the `Details` tab, automatically the `Summary` tab is updated.
+But if you modify the `Summary` tab, you need to save in order to have the `Details` tab updated.
+
+If you modify the `Summary` tab, and you need to do a change in the `Details` tab, please save before.
+
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
@@ -37,9 +45,6 @@ If you want other default ranges different from weekly, you need to go:
 Known issues / Roadmap
 ======================
 
-* When you change values on the `Summary` tab, a save should be performed
-  to ensure the data shown on the `Details` tab is correct. This limitation could be
-  perhaps avoided by including a .js file that aligns the `Details` tab.
 * The timesheet grid is limited to display a max. of 1M cells, due to a
   limitation of the tree view limit parameter not being able to dynamically
   set a limit. Since default value of odoo, 40 records is too small, we decided

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -506,9 +506,10 @@ class Sheet(models.Model):
         if project:
             values = self._prepare_empty_analytic_line(project, task)
             name_line = self._get_line_name(project, task)
-            if self.line_ids.mapped('value_y'):
+            name_list = list(set(self.line_ids.mapped('value_y')))
+            if name_list:
                 self.delete_empty_lines(False)
-            if name_line not in self.line_ids.mapped('value_y'):
+            if name_line not in name_list:
                 self.timesheet_ids |= \
                     self.env['account.analytic.line'].create(values)
                 self._onchange_timesheets()
@@ -526,7 +527,8 @@ class Sheet(models.Model):
         return timesheets
 
     def delete_empty_lines(self, delete_empty_rows=False):
-        for name in self.line_ids.mapped('value_y'):
+        name_list = list(set(self.line_ids.mapped('value_y')))
+        for name in name_list:
             row = self.line_ids.filtered(lambda l: l.value_y == name)
             if row:
                 row_0 = fields.first(row)

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -438,6 +438,8 @@ class Sheet(models.Model):
             'project_id': item[1].id,
             'task_id': item[2].id,
             'unit_amount': sum(t.unit_amount for t in matrix[item]),
+            'employee_id': self.employee_id.id,
+            'company_id': self.company_id.id,
         }
         if self.id:
             values.update({'sheet_id': self.id})
@@ -541,6 +543,14 @@ class SheetLine(models.TransientModel):
         string="Quantity",
         default=0.0,
     )
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        string='Company',
+    )
+    employee_id = fields.Many2one(
+        comodel_name='hr.employee',
+        string='Employee',
+    )
 
     @api.onchange('unit_amount')
     def onchange_unit_amount(self):
@@ -584,11 +594,11 @@ class SheetLine(models.TransientModel):
     def _line_to_timesheet(self, amount):
         return {
             'name': empty_name,
-            'employee_id': self.sheet_id.employee_id.id,
+            'employee_id': self.employee_id.id,
             'date': self.date,
             'project_id': self.project_id.id,
             'task_id': self.task_id.id,
             'sheet_id': self.sheet_id.id,
             'unit_amount': amount,
-            'company_id': self.sheet_id.company_id.id,
+            'company_id': self.company_id.id,
         }

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -122,6 +122,37 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(len(sheet.timesheet_ids), 0)
         self.assertEqual(len(sheet.line_ids), 0)
 
+    def test_1_B(self):
+        sheet = self.sheet_model.sudo(self.user).new({
+            'employee_id': self.employee.id,
+            'company_id': self.user.company_id.id,
+            'date_start': self.sheet_model._default_date_start(),
+            'date_end': self.sheet_model._default_date_end(),
+            'state': 'new',
+            'timesheet_ids': [(0, 0, {
+                'name': '/',
+                'project_id': self.project_1.id,
+                'employee_id': self.employee.id,
+                'unit_amount': 1,
+            })],
+        })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.timesheet_ids), 0)
+        self.assertEqual(len(sheet.line_ids), 0)
+        self.assertEqual(sheet.state, 'new')
+
+        line = self.sheet_line_model.new({
+            'project_id': self.project_1.id,
+            'employee_id': self.employee.id,
+            'sheet_id': sheet.id,
+            'unit_amount': 1,
+        })
+        line.onchange_unit_amount()
+        self.assertEqual(len(sheet.timesheet_ids), 0)
+        self.assertEqual(len(sheet.line_ids), 0)
+        self.assertEqual(sheet.state, 'new')
+
     def test_2(self):
         sheet = self.sheet_model.sudo(self.user).create({
             'employee_id': self.employee.id,

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -56,7 +56,7 @@
                                        field_value="unit_amount"
                                        x_axis_clickable="0"
                                        y_axis_clickable="1">
-                                    <!-- Well this is embarassing... we need to set a huge limit for records to be fetched in
+                                    <!-- Well this is embarrassing... we need to set a huge limit for records to be fetched in
                                     order to make sure that all rows are going to be displayed. At least until we find a method to
                                     dynamically define the limit.-->
                                     <tree limit="1000000">
@@ -67,6 +67,8 @@
                                         <field name="date"/>
                                         <field name="project_id"/>
                                         <field name="task_id"/>
+                                        <field name="company_id"/>
+                                        <field name="employee_id"/>
                                     </tree>
                                 </field>
                                 <group class="oe_edit_only" attrs="{'invisible': [('state', 'not in', ['new', 'draft'])]}">
@@ -90,6 +92,9 @@
                                     <field name="name"/>
                                     <field name="unit_amount" widget="float_time" string="Hours" sum="Hours"/>
                                     <field name="user_id" invisible="1"/>
+                                    <field name="sheet_id" invisible="1"/>
+                                    <field name="company_id" invisible="1"/>
+                                    <field name="employee_id" invisible="1"/>
                                 </tree>
                                 <form string="Timesheet Activities">
                                     <group>
@@ -99,6 +104,9 @@
                                         <field name="task_id" domain="[('project_id', '=', project_id)]" context="{'default_project_id': project_id}"/>
                                         <field name="unit_amount" widget="float_time" string="Hours"/>
                                         <field name="user_id" invisible="1"/>
+                                        <field name="sheet_id" invisible="1"/>
+                                        <field name="company_id" invisible="1"/>
+                                        <field name="employee_id" invisible="1"/>
                                     </group>
                                 </form>
                             </field>

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -44,6 +44,7 @@
                             <field name="name" invisible="1"/>
                             <field name="department_id" invisible="1"/>
                             <field name="company_id" groups="base.group_multi_company" force_save="1"/>
+                            <field name="_dummy_field" invisible="1"/>
                         </group>
                     </group>
                     <notebook>

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -79,6 +79,7 @@
                                             type="object"
                                             string="Add new line"
                                             class="oe_highlight"
+                                            attrs="{'invisible': [('add_line_project_id', '=', False)]}"
                                     />
                                 </group>
                             </group>


### PR DESCRIPTION
Update of https://github.com/OCA/hr-timesheet/pull/188.

I don't like two main things about this module:

 - One is that if you modify some data in the "Details" tab, you must have to save and click F5 to be able to see the same change in the "summary" tab.

- The other is that if you are in a timesheet sheet, already created, and in the form, in the "summary" tab you fill a 0 cell with some value, happens that if you cancel the edit and don't save the form, the timesheet related to that cell is already created.

So, I made this refactor to solve this two things. Now, the behaviour is like this:

* If you modify the `Details` tab, automatically the `Summary` tab is updated.
But if you modify the `Summary` tab, you need to save in order to have the `Details` tab updated.

* If you modify the `Summary` tab, and you need to do a change in the `Details` tab, please save before.