### PR TITLE
[11.0][IMP/FIX] hr_timesheet_sheet

### DIFF
--- a/hr_timesheet_sheet/README.rst
+++ b/hr_timesheet_sheet/README.rst
@@ -29,6 +29,14 @@ If you want other default ranges different from weekly, you need to go:
   and select in **Timesheet Sheet Range** the default range you want.
 * When you have a weekly range you can also specify the **Week Start Day**.
 
+Usage
+=====
+
+If you modify the `Details` tab, automatically the `Summary` tab is updated.
+But if you modify the `Summary` tab, you need to save in order to have the `Details` tab updated.
+
+In case you modify the unit amount of both tabs, the `Details` tab will prevail.
+If you modify the `Summary` tab, and you need to do a change in the `Details` tab, please save before.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
@@ -37,9 +45,6 @@ If you want other default ranges different from weekly, you need to go:
 Known issues / Roadmap
 ======================
 
-* When you change values on the `Summary` tab, a save should be performed
-  to ensure the data shown on the `Details` tab is correct. This limitation could be
-  perhaps avoided by including a .js file that aligns the `Details` tab.
 * The timesheet grid is limited to display a max. of 1M cells, due to a
   limitation of the tree view limit parameter not being able to dynamically
   set a limit. Since default value of odoo, 40 records is too small, we decided

--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'HR Timesheet Sheet',
-    'version': '11.0.1.4.0',
+    'version': '11.0.2.0.0',
     'category': 'Human Resources',
     'sequence': 80,
     'summary': 'Timesheet Sheets, Activities',

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -311,7 +311,9 @@ class Sheet(models.Model):
 
     @api.multi
     def copy(self, default=None):
-        raise UserError(_('You cannot duplicate a sheet.'))
+        if not self.env.context.get('allow_copy_timesheet'):
+            raise UserError(_('You cannot duplicate a sheet.'))
+        return super(Sheet, self).copy(default=default)
 
     @api.model
     def create(self, vals):
@@ -406,8 +408,14 @@ class Sheet(models.Model):
         for rec in self:
             if rec.state in ['new', 'draft']:
                 rec.add_line(rec.add_line_project_id, rec.add_line_task_id)
-                rec.add_line_task_id = False
-                rec.add_line_project_id = False
+                rec.reset_add_line()
+
+    @api.multi
+    def reset_add_line(self):
+        self.write({
+            'add_line_project_id': False,
+            'add_line_task_id': False,
+        })
 
     def _get_date_name(self, date):
         return fields.Date.from_string(date).strftime("%a\n%b %d")

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -102,7 +102,7 @@ class Sheet(models.Model):
         states={
             'new': [('readonly', False)],
             'draft': [('readonly', False)],
-        }
+        },
     )
     line_ids = fields.One2many(
         comodel_name='hr_timesheet.sheet.line',
@@ -112,7 +112,17 @@ class Sheet(models.Model):
         states={
             'new': [('readonly', False)],
             'draft': [('readonly', False)],
-        }
+        },
+    )
+    new_line_ids = fields.One2many(
+        comodel_name='hr_timesheet.sheet.new.analytic.line',
+        inverse_name='sheet_id',
+        string='Temporary Timesheets',
+        readonly=True,
+        states={
+            'new': [('readonly', False)],
+            'draft': [('readonly', False)],
+        },
     )
     state = fields.Selection([
         ('new', 'New'),
@@ -248,6 +258,7 @@ class Sheet(models.Model):
         ]
 
     @api.multi
+    @api.depends('date_start', 'date_end')
     def _compute_line_ids(self):
         for sheet in self:
             if not all([sheet.date_start, sheet.date_end]):
@@ -325,8 +336,10 @@ class Sheet(models.Model):
                       'you must link him/her to an user.'))
         res = super(Sheet, self).create(vals)
         res.write({'state': 'draft'})
-        self.delete_empty_lines(True)
         return res
+
+    def _sheet_write(self, field, recs):
+        self.with_context(sheet_write=True).write({field: [(6, 0, recs.ids)]})
 
     @api.multi
     def write(self, vals):
@@ -340,8 +353,11 @@ class Sheet(models.Model):
             self._check_sheet_date(forced_user_id=new_user_id)
         res = super(Sheet, self).write(vals)
         for rec in self:
-            if rec.state == 'draft':
-                rec.delete_empty_lines(True)
+            if rec.state == 'draft' and \
+                    not self.env.context.get('sheet_write'):
+                rec._update_analytic_lines_from_new_lines(vals)
+                if 'add_line_project_id' not in vals:
+                    rec.delete_empty_lines(True)
         return res
 
     @api.multi
@@ -447,6 +463,8 @@ class Sheet(models.Model):
             'project_id': item[1].id,
             'task_id': item[2].id,
             'unit_amount': sum(t.unit_amount for t in matrix[item]),
+            'employee_id': self.employee_id.id,
+            'company_id': self.company_id.id,
         }
         if self.id:
             values.update({'sheet_id': self.id})
@@ -471,9 +489,10 @@ class Sheet(models.Model):
         if project:
             values = self._prepare_empty_analytic_line(project, task)
             name_line = self._get_line_name(project, task)
-            if self.line_ids.mapped('value_y'):
+            name_list = list(set(self.line_ids.mapped('value_y')))
+            if name_list:
                 self.delete_empty_lines(False)
-            if name_line not in self.line_ids.mapped('value_y'):
+            if name_line not in name_list:
                 self.timesheet_ids |= \
                     self.env['account.analytic.line'].create(values)
 
@@ -490,21 +509,74 @@ class Sheet(models.Model):
         return timesheets
 
     def delete_empty_lines(self, delete_empty_rows=False):
-        for name in self.line_ids.mapped('value_y'):
+        for name in list(set(self.line_ids.mapped('value_y'))):
             row = self.line_ids.filtered(lambda l: l.value_y == name)
             if row:
-                ts_row = self.timesheet_ids.filtered(
-                    lambda x: x.project_id.id == row[0].project_id.id
-                    and x.task_id.id == row[0].task_id.id
-                )
-                if delete_empty_rows and self.add_line_project_id:
+                row_0 = fields.first(row)
+                is_add_line = self.add_line_project_id == row_0.project_id \
+                    and self.add_line_task_id == row_0.task_id
+                if delete_empty_rows and is_add_line:
                     check = any([l.unit_amount for l in row])
                 else:
                     check = not all([l.unit_amount for l in row])
                 if check:
+                    ts_row = self.timesheet_ids.filtered(
+                        lambda t: t.project_id.id == row_0.project_id.id
+                        and t.task_id.id == row_0.task_id.id
+                    )
                     ts_row.filtered(
                         lambda t: t.name == empty_name and not t.unit_amount
                     ).unlink()
+                    self._sheet_write(
+                        'timesheet_ids', self.timesheet_ids.exists())
+
+    @api.multi
+    def _update_analytic_lines_from_new_lines(self, vals):
+        self.ensure_one()
+        new_line_ids_list = []
+        for line in vals.get('line_ids', []):
+            # Every time we change a value in the grid a new line in line_ids
+            # is created with the proposed changes, even though the line_ids
+            # is a computed field. We capture the value of 'new_line_ids'
+            # in the proposed dict before it disappears.
+            # This field holds the ids of the transient records
+            # of model 'hr_timesheet.sheet.new.analytic.line'.
+            if line[0] == 1 and line[2] and line[2].get('new_line_id'):
+                new_line_ids_list += [line[2].get('new_line_id')]
+        for new_line in self.new_line_ids.exists():
+            if new_line.id in new_line_ids_list:
+                new_line._update_analytic_lines()
+        self.new_line_ids.exists().unlink()
+        self._sheet_write('new_line_ids', self.new_line_ids.exists())
+
+    @api.model
+    def _prepare_new_line(self, line):
+        return {
+            'sheet_id': line.sheet_id.id,
+            'date': line.date,
+            'project_id': line.project_id.id,
+            'task_id': line.task_id.id,
+            'unit_amount': line.unit_amount,
+            'company_id': line.company_id.id,
+            'employee_id': line.employee_id.id,
+        }
+
+    @api.multi
+    def add_new_line(self, line):
+        self.ensure_one()
+        new_line_model = self.env['hr_timesheet.sheet.new.analytic.line']
+        new_line = self.new_line_ids.filtered(
+            lambda l: l.project_id.id == line.project_id.id
+            and l.task_id.id == line.task_id.id
+            and l.date == line.date
+        )
+        if new_line:
+            new_line.write({'unit_amount': line.unit_amount})
+        else:
+            vals = self._prepare_new_line(line)
+            new_line = new_line_model.create(vals)
+        self._sheet_write('new_line_ids', self.new_line_ids | new_line)
+        line.new_line_id = new_line.id
 
     # ------------------------------------------------
     # OpenChatter methods and notifications
@@ -521,17 +593,15 @@ class Sheet(models.Model):
         return super(Sheet, self)._track_subtype(init_values)
 
 
-class SheetLine(models.TransientModel):
-    _name = 'hr_timesheet.sheet.line'
-    _description = 'Timesheet Sheet Line'
+class AbstractSheetLine(models.AbstractModel):
+    _name = 'hr_timesheet.sheet.line.abstract'
+    _description = 'Abstract Timesheet Sheet Line'
 
     sheet_id = fields.Many2one(
         comodel_name='hr_timesheet.sheet',
         ondelete='cascade',
     )
-    date = fields.Date(
-        string='Date',
-    )
+    date = fields.Date()
     project_id = fields.Many2one(
         comodel_name='project.project',
         string='Project',
@@ -540,36 +610,66 @@ class SheetLine(models.TransientModel):
         comodel_name='project.task',
         string='Task',
     )
+    unit_amount = fields.Float(
+        string="Quantity",
+        default=0.0,
+    )
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        string='Company',
+    )
+    employee_id = fields.Many2one(
+        comodel_name='hr.employee',
+        string='Employee',
+    )
+
+
+class SheetLine(models.TransientModel):
+    _name = 'hr_timesheet.sheet.line'
+    _inherit = 'hr_timesheet.sheet.line.abstract'
+    _description = 'Timesheet Sheet Line'
+
     value_x = fields.Char(
         string='Date Name',
     )
     value_y = fields.Char(
         string='Project Name',
     )
-    unit_amount = fields.Float(
-        string="Quantity",
-        default=0.0,
+    new_line_id = fields.Integer(
+        default=0,
     )
 
     @api.onchange('unit_amount')
     def onchange_unit_amount(self):
-        """This method is called when filling a cell of the matrix.
-        It checks if there exists timesheets associated  to that cell.
-        If yes, it does several comparisons to see if the unit_amount of
-        the timesheets should be updated accordingly."""
+        """ This method is called when filling a cell of the matrix. """
         self.ensure_one()
+        sheet = self._get_sheet()
+        if not sheet:
+            return {'warning': {
+                'title': _("Warning"),
+                'message': _("Save the Timesheet Sheet first."),
+            }}
+        sheet.add_new_line(self)
 
+    @api.model
+    def _get_sheet(self):
         sheet = self.sheet_id
         if not sheet:
             model = self.env.context.get('params', {}).get('model', '')
             obj_id = self.env.context.get('params', {}).get('id')
             if model == 'hr_timesheet.sheet' and isinstance(obj_id, int):
                 sheet = self.env['hr_timesheet.sheet'].browse(obj_id)
-        if not sheet:
-            return {'warning': {
-                'title': _("Warning"),
-                'message': _("Save the Timesheet Sheet first.")
-            }}
+        return sheet
+
+
+class SheetNewAnalyticLine(models.TransientModel):
+    _name = 'hr_timesheet.sheet.new.analytic.line'
+    _inherit = 'hr_timesheet.sheet.line.abstract'
+    _description = 'Timesheet Sheet New Analytic Line'
+
+    @api.model
+    def _update_analytic_lines(self):
+        sheet = self.sheet_id
         timesheets = sheet.timesheet_ids.filtered(
             lambda t: t.date == self.date
             and t.project_id.id == self.project_id.id
@@ -578,26 +678,23 @@ class SheetLine(models.TransientModel):
         new_ts = timesheets.filtered(lambda t: t.name == empty_name)
         amount = sum(t.unit_amount for t in timesheets)
         diff_amount = self.unit_amount - amount
+        if len(new_ts) > 1:
+            new_ts = new_ts.merge_timesheets()
+            sheet._sheet_write('timesheet_ids', sheet.timesheet_ids.exists())
         if not diff_amount:
             return
         if new_ts:
-            if len(new_ts) > 1:
-                new_ts = new_ts.merge_timesheets()
             unit_amount = new_ts.unit_amount + diff_amount
-            new_ts.write({'unit_amount': unit_amount})
+            if unit_amount:
+                new_ts.write({'unit_amount': unit_amount})
+            else:
+                new_ts.unlink()
+                sheet._sheet_write(
+                    'timesheet_ids', sheet.timesheet_ids.exists())
         else:
-            new_ts_values = self._line_to_timesheet(diff_amount)
+            new_ts_values = sheet._prepare_new_line(self)
+            new_ts_values.update({
+                'name': empty_name,
+                'unit_amount': diff_amount,
+            })
             self.env['account.analytic.line'].create(new_ts_values)
-
-    @api.model
-    def _line_to_timesheet(self, amount):
-        return {
-            'name': empty_name,
-            'employee_id': self.sheet_id.employee_id.id,
-            'date': self.date,
-            'project_id': self.project_id.id,
-            'task_id': self.task_id.id,
-            'sheet_id': self.sheet_id.id,
-            'unit_amount': amount,
-            'company_id': self.sheet_id.company_id.id,
-        }

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2018-2019 Eficent Business and IT Consulting Services, S.L.
 # Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
 # Copyright 2018-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0
@@ -105,10 +105,12 @@ class TestHrTimesheetSheet(TransactionCase):
             'company_id': self.user.company_id.id,
         })
 
-    def test_1(self):
+    def test_0(self):
         sheet = self.sheet_model.sudo(self.user).create({
             'company_id': self.user.company_id.id,
         })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 0)
         self.assertEqual(len(sheet.line_ids), 0)
         self.assertTrue(sheet.employee_id)
@@ -116,8 +118,8 @@ class TestHrTimesheetSheet(TransactionCase):
         sheet.add_line_project_id = self.project_1
         sheet.onchange_add_project_id()
         sheet.sudo(self.user).button_add_line()
-        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 1)
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.line_ids), 7)
 
         sheet.date_end = fields.Date.to_string(
@@ -126,12 +128,95 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(len(sheet.timesheet_ids), 0)
         self.assertEqual(len(sheet.line_ids), 0)
 
+    def test_1(self):
+        sheet = self.sheet_model.sudo(self.user).new({
+            'employee_id': self.employee.id,
+            'company_id': self.user.company_id.id,
+            'date_start': self.sheet_model._default_date_start(),
+            'date_end': self.sheet_model._default_date_end(),
+            'state': 'new',
+        })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.timesheet_ids), 0)
+        self.assertEqual(len(sheet.line_ids), 0)
+
+        timesheet = self.aal_model.create({
+            'name': 'test',
+            'project_id': self.project_1.id,
+            'employee_id': self.employee.id,
+            'sheet_id': sheet.id,
+        })
+        sheet.timesheet_ids = timesheet
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.timesheet_ids), 1)
+        self.assertEqual(len(sheet.line_ids), 7)
+        self.assertFalse(any([l.unit_amount for l in sheet.line_ids]))
+        self.assertEqual(timesheet.unit_amount, 0)
+
+        timesheet.unit_amount = 1.0
+        self.assertEqual(len(sheet.timesheet_ids), 1)
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.timesheet_ids), 1)
+        self.assertEqual(len(sheet.line_ids), 7)
+        self.assertTrue(any([l.unit_amount for l in sheet.line_ids]))
+
+        line = sheet.line_ids.filtered(lambda l: l.unit_amount)
+        line.unit_amount = 2.0
+        line.onchange_unit_amount()
+        self.assertEqual(line.unit_amount, 2.0)
+        self.assertEqual(timesheet.unit_amount, 1.0)
+
+        sheet = self.sheet_model.sudo(self.user).create(
+            sheet._convert_to_write(sheet._cache))
+        self.assertEqual(len(sheet.timesheet_ids), 1)
+        self.assertEqual(len(sheet.line_ids), 7)
+
+    def test_1_B(self):
+        sheet = self.sheet_model.sudo(self.user).new({
+            'employee_id': self.employee.id,
+            'company_id': self.user.company_id.id,
+            'date_start': self.sheet_model._default_date_start(),
+            'date_end': self.sheet_model._default_date_end(),
+            'state': 'new',
+            'timesheet_ids': [(0, 0, {
+                'name': empty_name,
+                'date': self.sheet_model._default_date_start(),
+                'project_id': self.project_1.id,
+                'employee_id': self.employee.id,
+                'unit_amount': 1,
+            })],
+        })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.timesheet_ids), 0)
+        self.assertEqual(len(sheet.line_ids), 0)
+        self.assertEqual(sheet.state, 'new')
+
+        line = self.sheet_line_model.new({
+            'date': self.sheet_model._default_date_start(),
+            'project_id': self.project_1.id,
+            'employee_id': self.employee.id,
+            'sheet_id': sheet.id,
+            'unit_amount': 1,
+        })
+        line.onchange_unit_amount()
+        self.assertEqual(len(sheet.timesheet_ids), 0)
+        self.assertEqual(len(sheet.line_ids), 0)
+        self.assertEqual(sheet.state, 'new')
+
+        created_sheet = self.sheet_model.sudo(self.user).create(
+            sheet._convert_to_write(sheet._cache))
+        self.assertEqual(created_sheet.state, 'draft')
+
     def test_2(self):
         sheet = self.sheet_model.sudo(self.user).create({
             'employee_id': self.employee.id,
             'company_id': self.user.company_id.id,
             'department_id': self.department.id,
         })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 0)
         self.assertEqual(len(sheet.line_ids), 0)
 
@@ -143,31 +228,44 @@ class TestHrTimesheetSheet(TransactionCase):
         sheet.add_line_project_id = self.project_1
         sheet.onchange_add_project_id()
         sheet.sudo(self.user).button_add_line()
+        self.assertFalse(sheet.add_line_project_id.id)
+        self.assertEqual(len(sheet.timesheet_ids), 1)
         sheet._onchange_timesheets()
-        sheet.onchange_add_project_id()
-        self.assertEqual(sheet.add_line_project_id.id, False)
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 1)
-        timesheet = sheet.timesheet_ids[0]
 
-        line = sheet.line_ids.filtered(lambda l: l.date != timesheet.date)[0]
-        self.assertEqual(line.unit_amount, 0.0)
-        line._cache.update(
-            line._convert_to_cache(
-                {'unit_amount': 1.0}, update=True))
+        line = fields.first(sheet.line_ids)
+        line.unit_amount = 2.0
         line.onchange_unit_amount()
-        self.assertEqual(line.unit_amount, 1.0)
+        self.assertEqual(len(sheet.new_line_ids), 1)
+        new_line = fields.first(sheet.new_line_ids)
+        sheet.write({
+            'line_ids': [(1, 0, {'new_line_id': new_line.id})]
+        })
+        self.assertEqual(line.unit_amount, 2.0)
+        self.assertEqual(len(sheet.timesheet_ids), 1)
+        timesheet = fields.first(sheet.timesheet_ids)
+
+        other_lines = sheet.line_ids.filtered(
+            lambda l: l.date != timesheet.date)
+        line2 = fields.first(other_lines)
+        self.assertEqual(line2.unit_amount, 0.0)
+        line2.unit_amount = 1.0
+        line2.onchange_unit_amount()
+        self.assertEqual(len(sheet.new_line_ids), 1)
+        new_line = fields.first(sheet.new_line_ids)
+        sheet.write({
+            'line_ids': [(1, 0, {'new_line_id': new_line.id})]
+        })
+        self.assertEqual(line2.unit_amount, 1.0)
         self.assertEqual(len(sheet.timesheet_ids), 2)
 
         sheet.add_line_project_id = self.project_2
         sheet.onchange_add_project_id()
         sheet.sudo(self.user).button_add_line()
-        sheet._onchange_timesheets()
-        self.assertEqual(len(sheet.timesheet_ids), 2)
-        self.assertNotIn(timesheet.id, sheet.timesheet_ids.ids)
-        self.assertEqual(len(sheet.line_ids), 14)
-        timesheet = sheet.timesheet_ids.filtered(
-            lambda t: t.unit_amount != 0.0)
+        self.assertEqual(len(sheet.timesheet_ids), 3)
+        self.assertIn(timesheet.id, sheet.timesheet_ids.ids)
+        self.assertEqual(len(sheet.line_ids), 7)
 
         self.assertEqual(sheet.state, 'draft')
         sheet.action_timesheet_confirm()
@@ -178,7 +276,7 @@ class TestHrTimesheetSheet(TransactionCase):
         # Confirmed timesheet cannot be modified
         with self.assertRaises(UserError):
             timesheet.unit_amount = 0.0
-        self.assertEqual(timesheet.unit_amount, 1.0)
+        self.assertEqual(timesheet.unit_amount, 2.0)
 
         # Force confirmed timesheet to be modified
         timesheet.with_context(skip_check_state=True).unit_amount = 0.0
@@ -205,9 +303,10 @@ class TestHrTimesheetSheet(TransactionCase):
             'company_id': self.user.company_id.id,
             'date_start': self.sheet_model._default_date_start(),
             'date_end': self.sheet_model._default_date_end(),
-            'state': 'draft',
+            'state': 'new',
         })
         sheet._onchange_dates()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertTrue(self.aal_model.search([('id', '=', timesheet.id)]))
@@ -261,21 +360,28 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(timesheet_3.unit_amount, 0.0)
 
         line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
+        self.assertEqual(len(line), 1)
         self.assertEqual(line.unit_amount, 1.0)
         line.unit_amount = 0.0
         line.onchange_unit_amount()
-        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.new_line_ids), 1)
+        new_line = fields.first(sheet.new_line_ids)
+        sheet.write({
+            'line_ids': [(1, 0, {'new_line_id': new_line.id})]
+        })
+        self.assertEqual(line.unit_amount, 0.0)
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertFalse(self.aal_model.search(
             [('id', '=', timesheet_1_or_2.id)]))
 
         timesheet_3.name = empty_name
+        sheet._onchange_timesheets()
         sheet.add_line_project_id = self.project_2
         sheet.onchange_add_project_id()
         sheet.add_line_task_id = self.task_2
         sheet.sudo(self.user).button_add_line()
-        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 1)
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertFalse(self.aal_model.search(
             [('id', '=', timesheet_3.id)]))
@@ -305,33 +411,41 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(line.unit_amount, 4.0)
 
         timesheet_2.name = empty_name
-        line._cache.update(
-            line._convert_to_cache(
-                {'unit_amount': 3.0}, update=True))
-        line.onchange_unit_amount()
         sheet._onchange_timesheets()
+        line.unit_amount = 3.0
+        line.onchange_unit_amount()
+        self.assertEqual(len(sheet.new_line_ids), 1)
+        new_line = fields.first(sheet.new_line_ids)
+        sheet.write({
+            'line_ids': [(1, 0, {'new_line_id': new_line.id})]
+        })
         self.assertEqual(len(sheet.timesheet_ids), 1)
-        self.assertEqual(sheet.timesheet_ids[0].unit_amount, 3.0)
+        self.assertEqual(fields.first(sheet.timesheet_ids).unit_amount, 3.0)
 
         timesheet_1_or_2 = self.aal_model.search(
             [('id', 'in', [timesheet_1.id, timesheet_2.id])])
         self.assertEqual(len(timesheet_1_or_2), 1)
         self.assertEqual(timesheet_1_or_2.unit_amount, 3.0)
 
-        line._cache.update(
-            line._convert_to_cache(
-                {'unit_amount': 4.0}, update=True))
+        line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
+        line.unit_amount = 4.0
         line.onchange_unit_amount()
-        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.new_line_ids), 1)
+        new_line = fields.first(sheet.new_line_ids)
+        sheet.write({
+            'line_ids': [(1, 0, {'new_line_id': new_line.id})]
+        })
         self.assertEqual(len(sheet.timesheet_ids), 1)
-        self.assertEqual(sheet.timesheet_ids[0].unit_amount, 4.0)
+        self.assertEqual(fields.first(sheet.timesheet_ids).unit_amount, 4.0)
         self.assertEqual(timesheet_1_or_2.unit_amount, 4.0)
 
-        line._cache.update(
-            line._convert_to_cache(
-                {'unit_amount': -1.0}, update=True))
+        line.unit_amount = -1.0
         line.onchange_unit_amount()
-        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.new_line_ids), 1)
+        new_line = fields.first(sheet.new_line_ids)
+        sheet.write({
+            'line_ids': [(1, 0, {'new_line_id': new_line.id})]
+        })
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 1)
 
@@ -378,21 +492,29 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(line.unit_amount, 10.0)
 
         timesheet_2.name = empty_name
-        line._cache.update(
-            line._convert_to_cache(
-                {'unit_amount': 6.0}, update=True))
-        line.onchange_unit_amount()
         sheet._onchange_timesheets()
+        line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
+        line.unit_amount = 6.0
+        line.onchange_unit_amount()
+        self.assertEqual(len(sheet.new_line_ids), 1)
+        new_line = fields.first(sheet.new_line_ids)
+        sheet.write({
+            'line_ids': [(1, 0, {'new_line_id': new_line.id})]
+        })
         self.assertEqual(len(sheet.timesheet_ids), 3)
 
         timesheet_1_or_2 = self.aal_model.search(
             [('id', 'in', [timesheet_1.id, timesheet_2.id])])
         self.assertFalse(timesheet_1_or_2)
 
-        line._cache.update(
-            line._convert_to_cache(
-                {'unit_amount': 3.0}, update=True))
+        line.unit_amount = 3.0
         line.onchange_unit_amount()
+        self.assertEqual(len(sheet.new_line_ids), 1)
+        new_line = fields.first(sheet.new_line_ids)
+        sheet.write({
+            'line_ids': [(1, 0, {'new_line_id': new_line.id})]
+        })
+        self.assertEqual(len(sheet.timesheet_ids), 4)
         sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 4)
         self.assertEqual(line.unit_amount, 3.0)
@@ -414,13 +536,15 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(len(line), 1)
         self.assertEqual(line.unit_amount, 5.0)
 
-        line._cache.update(
-            line._convert_to_cache(
-                {'unit_amount': 1.0}, update=True))
+        line.unit_amount = 1.0
         line.onchange_unit_amount()
-        sheet._onchange_timesheets()
+        self.assertEqual(len(sheet.new_line_ids), 1)
+        new_line = fields.first(sheet.new_line_ids)
+        sheet.write({
+            'line_ids': [(1, 0, {'new_line_id': new_line.id})]
+        })
         self.assertEqual(len(sheet.timesheet_ids), 4)
-        self.assertTrue(self.aal_model.search([('id', '=', timesheet_6.id)]))
+        self.assertTrue(timesheet_6.exists().ids)
 
     def test_7(self):
         sheet = self.sheet_model.sudo(self.user).new({
@@ -428,8 +552,9 @@ class TestHrTimesheetSheet(TransactionCase):
             'company_id': self.user.company_id.id,
             'date_start': self.sheet_model._default_date_end(),
             'date_end': self.sheet_model._default_date_start(),
-            'state': 'draft',
+            'state': 'new',
         })
+        sheet._onchange_dates()
         sheet._onchange_timesheets()
         self.assertEqual(len(sheet.line_ids), 0)
         self.assertEqual(len(sheet.timesheet_ids), 0)
@@ -441,6 +566,7 @@ class TestHrTimesheetSheet(TransactionCase):
             'employee_id': self.employee.id,
             'company_id': self.user.company_id.id,
         })
+        sheet._onchange_dates()
         with self.assertRaises(UserError):
             sheet.sudo(self.user).copy()
         with self.assertRaises(ValidationError):
@@ -474,6 +600,8 @@ class TestHrTimesheetSheet(TransactionCase):
             'company_id': self.user.company_id.id,
             'department_id': self.department.id,
         })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
         with self.assertRaises(ValidationError):
             sheet.company_id = self.user_2.company_id.id
         sheet.company_id = self.user.company_id.id
@@ -492,12 +620,11 @@ class TestHrTimesheetSheet(TransactionCase):
             'company_id': self.user.company_id.id,
             'department_id': self.department.id,
         })
-
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
         sheet.add_line_project_id = self.project_1
         sheet.onchange_add_project_id()
         sheet.sudo(self.user).button_add_line()
-        sheet._onchange_timesheets()
-        sheet.onchange_add_project_id()
         self.assertEqual(len(sheet.timesheet_ids), 1)
 
         sheet.action_timesheet_confirm()
@@ -519,6 +646,8 @@ class TestHrTimesheetSheet(TransactionCase):
             'employee_id': self.employee.id,
             'company_id': self.company.id,
         })
+        sheet._onchange_dates()
+        sheet._onchange_timesheets()
         date_start = fields.Date.from_string(sheet.date_start)
         date_end = fields.Date.from_string(sheet.date_end)
         weekday_from = date_start.weekday()
@@ -526,7 +655,6 @@ class TestHrTimesheetSheet(TransactionCase):
 
         self.assertEqual(weekday_from, 6, "The timesheet should start on "
                                           "Sunday")
-
         self.assertEqual(weekday_to, 5, "The timesheet should end on Saturday")
 
     def test_11_onchange_unit_amount(self):
@@ -551,13 +679,14 @@ class TestHrTimesheetSheet(TransactionCase):
             'department_id': self.department.id,
             'date_start': self.sheet_model._default_date_start(),
             'date_end': self.sheet_model._default_date_end(),
-            'state': 'draft',
+            'state': 'new',
         })
         sheet._onchange_dates()
         sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 2)
         self.assertEqual(len(sheet.line_ids), 7)
 
+        unit_amount = 0.0
         for line in sheet.line_ids:
             if line.unit_amount:
                 line.sheet_id = False
@@ -569,15 +698,12 @@ class TestHrTimesheetSheet(TransactionCase):
                 self.assertFalse(res_onchange)
                 self.assertEqual(line.unit_amount, unit_amount + 1.0)
 
-        sheet._onchange_dates()
-        self.assertEqual(len(sheet.timesheet_ids), 3)
+        self.assertEqual(len(sheet.timesheet_ids), 2)
         self.assertEqual(len(sheet.line_ids), 7)
+        self.assertEqual(len(sheet.new_line_ids), 1)
 
-        new_timesheet = sheet.timesheet_ids.filtered(
-            lambda t: t.name == empty_name
-        )
-        self.assertEqual(len(new_timesheet), 1)
-        self.assertEqual(new_timesheet.unit_amount, 1.0)
+        new_line = fields.first(sheet.new_line_ids)
+        self.assertEqual(new_line.unit_amount, unit_amount + 1.0)
 
         for line in sheet.line_ids:
             if line.unit_amount:
@@ -676,6 +802,7 @@ class TestHrTimesheetSheet(TransactionCase):
         })
         self.assertEqual(sheet.company_id, self.company)
         sheet._onchange_dates()
+        sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertEqual(sheet.timesheet_ids.company_id, self.company)
 
@@ -685,7 +812,7 @@ class TestHrTimesheetSheet(TransactionCase):
         with self.assertRaises(ValidationError):
             analytic_account.company_id = self.company_2
 
-    def test_14(self):
+    def test_15(self):
         department = self.department_model.create({
             'name': "Department test",
             'company_id': False,

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -56,7 +56,7 @@
                                        field_value="unit_amount"
                                        x_axis_clickable="0"
                                        y_axis_clickable="1">
-                                    <!-- Well this is embarassing... we need to set a huge limit for records to be fetched in
+                                    <!-- Well this is embarrassing... we need to set a huge limit for records to be fetched in
                                     order to make sure that all rows are going to be displayed. At least until we find a method to
                                     dynamically define the limit.-->
                                     <tree limit="1000000">
@@ -67,6 +67,10 @@
                                         <field name="date"/>
                                         <field name="project_id"/>
                                         <field name="task_id"/>
+                                        <field name="company_id" groups="base.group_multi_company"/>
+                                        <field name="employee_id"/>
+                                        <field name="new_line_id" invisible="1"/>
+                                        <!--  Don't remove last fields, they are technically needed for the widget to work properly.-->
                                     </tree>
                                 </field>
                                 <group class="oe_edit_only" attrs="{'invisible': [('state', 'not in', ['new', 'draft'])]}">
@@ -77,6 +81,7 @@
                                             type="object"
                                             string="Add new line"
                                             class="oe_highlight"
+                                            attrs="{'invisible': [('add_line_project_id', '=', False)]}"
                                     />
                                 </group>
                             </group>


### PR DESCRIPTION
This PR fixes:

- If you are in a timesheet sheet, already created, and in the form, in the "summary" tab you fill a 0 cell with some value, happens that if you cancel the edit and don't save the form, the timesheet related to that cell is already created.

And minor improvements.