### PR TITLE
[10.0][FIX]hr_timesheet_sheet_restrict_project. Not working.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "2.7"
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/hr_timesheet_sheet_restrict_project/views/hr_timesheet_restrict_project.xml
+++ b/hr_timesheet_sheet_restrict_project/views/hr_timesheet_restrict_project.xml
@@ -5,7 +5,7 @@
               inherit_id="web.assets_backend">
         <xpath expr="." position="inside">
             <script type="text/javascript"
-                    src="/hr_timesheet_sheet_restrict_analytic/static/src/js/restrict_timesheet.js"/>
+                    src="/hr_timesheet_sheet_restrict_project/static/src/js/restrict_timesheet.js"/>
         </xpath>
     </template>
 


### PR DESCRIPTION
Edited: When renaming the module, a reference was not renamed, that is the issue.