### PR TITLE
[11.0][FIX] hr_timesheet_sheet: tests

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2018 Eficent
-# Copyright 2019 Brainbean Apps
+# Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
 # Copyright 2018-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -1,11 +1,15 @@
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
 # Copyright 2018-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0
 
 from odoo import fields
 from dateutil.relativedelta import relativedelta
+
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import UserError, ValidationError
+
+from ..models.hr_timesheet_sheet import empty_name
 
 
 class TestHrTimesheetSheet(TransactionCase):
@@ -192,7 +196,7 @@ class TestHrTimesheetSheet(TransactionCase):
 
     def test_3(self):
         timesheet = self.aal_model.create({
-            'name': '/',
+            'name': empty_name,
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
         })
@@ -220,12 +224,12 @@ class TestHrTimesheetSheet(TransactionCase):
 
     def test_4(self):
         timesheet_1 = self.aal_model.create({
-            'name': '/',
+            'name': empty_name,
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
         })
         timesheet_2 = self.aal_model.create({
-            'name': '/',
+            'name': empty_name,
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
             'unit_amount': 1.0,
@@ -265,7 +269,7 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertFalse(self.aal_model.search(
             [('id', '=', timesheet_1_or_2.id)]))
 
-        timesheet_3.name = '/'
+        timesheet_3.name = empty_name
         sheet.add_line_project_id = self.project_2
         sheet.onchange_add_project_id()
         sheet.add_line_task_id = self.task_2
@@ -278,7 +282,7 @@ class TestHrTimesheetSheet(TransactionCase):
 
     def test_5(self):
         timesheet_1 = self.aal_model.create({
-            'name': '/',
+            'name': empty_name,
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
             'unit_amount': 2.0,
@@ -300,7 +304,7 @@ class TestHrTimesheetSheet(TransactionCase):
         line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
         self.assertEqual(line.unit_amount, 4.0)
 
-        timesheet_2.name = '/'
+        timesheet_2.name = empty_name
         line._cache.update(
             line._convert_to_cache(
                 {'unit_amount': 3.0}, update=True))
@@ -333,7 +337,7 @@ class TestHrTimesheetSheet(TransactionCase):
 
     def test_6(self):
         timesheet_1 = self.aal_model.create({
-            'name': '/',
+            'name': empty_name,
             'project_id': self.project_1.id,
             'employee_id': self.employee.id,
             'unit_amount': 2.0,
@@ -373,7 +377,7 @@ class TestHrTimesheetSheet(TransactionCase):
         line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
         self.assertEqual(line.unit_amount, 10.0)
 
-        timesheet_2.name = '/'
+        timesheet_2.name = empty_name
         line._cache.update(
             line._convert_to_cache(
                 {'unit_amount': 6.0}, update=True))
@@ -403,7 +407,7 @@ class TestHrTimesheetSheet(TransactionCase):
             'employee_id': self.employee.id,
             'unit_amount': 2.0,
         })
-        timesheet_5.name = '/'
+        timesheet_5.name = empty_name
         sheet._onchange_timesheets()
         self.assertEqual(len(sheet.timesheet_ids), 4)
         line = sheet.line_ids.filtered(lambda l: l.unit_amount != 0.0)
@@ -569,7 +573,9 @@ class TestHrTimesheetSheet(TransactionCase):
         self.assertEqual(len(sheet.timesheet_ids), 3)
         self.assertEqual(len(sheet.line_ids), 7)
 
-        new_timesheet = sheet.timesheet_ids.filtered(lambda t: t.name == '/')
+        new_timesheet = sheet.timesheet_ids.filtered(
+            lambda t: t.name == empty_name
+        )
         self.assertEqual(len(new_timesheet), 1)
         self.assertEqual(new_timesheet.unit_amount, 1.0)
 


### PR DESCRIPTION
Backport of https://github.com/OCA/timesheet/pull/247 but in reality tests were different in v11 and thus v12 had an issue. This should make tests consistent @astirpe @pedrobaeza 