### PR TITLE
[11.0][FIX] hr_timesheet_sheet: don't remove lines on timesheet sheet removal

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -376,11 +376,6 @@ class Sheet(models.Model):
                 raise UserError(
                     _('You cannot delete a timesheet sheet '
                       'which is already confirmed.'))
-        analytic_timesheet_toremove = self.env['account.analytic.line']
-        for sheet in self:
-            analytic_timesheet_toremove += \
-                sheet.timesheet_ids.filtered(lambda t: t.name == empty_name)
-        analytic_timesheet_toremove.unlink()
         return super(Sheet, self).unlink()
 
     def _timesheet_subscribe_users(self):


### PR DESCRIPTION
Backport of #269.
Fixes #267.