### PR TITLE
[FIX] hr_timesheet_task_stage: Disable automatic hotkeys

### DIFF
--- a/hr_timesheet_task_stage/views/account_analytic_line.xml
+++ b/hr_timesheet_task_stage/views/account_analytic_line.xml
@@ -15,6 +15,7 @@
                 <button
                     name="action_close_task"
                     string="Close task"
+                    tabindex="-1"
                     type="object"
                     icon="fa-folder-o"
                     attrs="{'invisible': ['|', ('is_task_closed', '=', True), ('task_id', '=', False)]}"
@@ -22,6 +23,7 @@
                 <button
                     name="action_open_task"
                     string="Open task"
+                    tabindex="-1"
                     type="object"
                     icon="fa-folder-open-o"
                     attrs="{'invisible': ['|', ('is_task_closed', '=', False), ('task_id', '=', False)]}"


### PR DESCRIPTION
Without this attribute, Odoo will try to assign a hotkey to buttons. It's very unlikely that these buttons have to be used like this, and since there's a limited number of available hotkeys, they steal them to more important ones like the wizard proposed at https://github.com/OCA/project/pull/586.

See how it looks like without this patch:
![Captura de pantalla de 2019-10-02 10-46-09](https://user-images.githubusercontent.com/973709/66035245-ab692200-e502-11e9-98d8-ec4248ce21b4.png)

[Here you can see how the patch works](https://github.com/odoo/odoo/blob/2ccf05940681cfdb783cd42c5627c65a80076f60/addons/web/static/src/js/chrome/keyboard_navigation_mixin.js#L135).

@Tecnativa TT19205