### PR TITLE
[IMP] crm_timesheet: Tell the user no running line was found

### DIFF
--- a/crm_timesheet/models/crm_lead.py
+++ b/crm_timesheet/models/crm_lead.py
@@ -3,21 +3,16 @@
 # Copyright 2017 David Vidal <david.vidal@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo import api, fields, models
 
 
 class CrmLead(models.Model):
-    _inherit = 'crm.lead'
+    _name = 'crm.lead'
+    _inherit = ['crm.lead', "hr.timesheet.time_control.mixin"]
 
     project_id = fields.Many2one(
         comodel_name='project.project',
         string="Project",
-    )
-    show_time_control = fields.Selection(
-        selection=[("start", "Start"), ("stop", "Stop")],
-        compute="_compute_show_time_control",
-        help="Indicate which time control button to show, if any.",
     )
     timesheet_ids = fields.One2many(
         comodel_name='account.analytic.line',
@@ -26,52 +21,16 @@ class CrmLead(models.Model):
     )
 
     @api.model
-    def _timesheet_running_domain(self):
-        """Domain to find running timesheet lines."""
-        return self.env["account.analytic.line"]._running_domain() + [
-            ("lead_id", "in", self.ids),
-        ]
+    def _relation_with_timesheet_line(self):
+        return "lead_id"
 
     @api.depends("timesheet_ids.employee_id", "timesheet_ids.unit_amount")
     def _compute_show_time_control(self):
-        """Decide which time control button to show, if any."""
-        grouped = self.env["account.analytic.line"].read_group(
-            domain=self._timesheet_running_domain(),
-            fields=["id"],
-            groupby=["lead_id"],
-        )
-        lines_per_lead = {group["lead_id"][0]: group["lead_id_count"]
-                          for group in grouped}
-        button_per_lines = {0: "start", 1: "stop"}
-        for lead in self:
-            lead.show_time_control = button_per_lines.get(
-                lines_per_lead.get(lead.id, 0),
-                False,
-            )
+        return super()._compute_show_time_control()
 
     def button_start_work(self):
-        """Create a new record starting now, with a running timer."""
-        return {
-            "context": {
-                "default_project_id": self.project_id.id,
-                "default_lead_id": self.id,
-            },
-            "name": _("Start work"),
-            "res_model": "hr.timesheet.switch",
-            "target": "new",
-            "type": "ir.actions.act_window",
-            "view_mode": "form",
-            "view_type": "form",
-        }
-
-    @api.multi
-    def button_end_work(self):
-        running_lines = self.env["account.analytic.line"].search(
-            self._timesheet_running_domain(),
-        )
-        if not running_lines:
-            raise UserError(
-                _("No running timer found in lead/opportunity %s. "
-                  "Refresh the page and check again.") % self.display_name,
-            )
-        return running_lines.button_end_work()
+        result = super().button_start_work()
+        result["context"].update({
+            "default_project_id": self.project_id.id,
+        })
+        return result

--- a/crm_timesheet/models/crm_lead.py
+++ b/crm_timesheet/models/crm_lead.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class CrmLead(models.Model):
@@ -68,4 +69,9 @@ class CrmLead(models.Model):
         running_lines = self.env["account.analytic.line"].search(
             self._timesheet_running_domain(),
         )
+        if not running_lines:
+            raise UserError(
+                _("No running timer found in lead/opportunity %s. "
+                  "Refresh the page and check again.") % self.display_name,
+            )
         return running_lines.button_end_work()

--- a/crm_timesheet/tests/test_account_analytic_line.py
+++ b/crm_timesheet/tests/test_account_analytic_line.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import date, datetime, timedelta
+from odoo import exceptions
 from odoo.tests.common import SavepointCase
 
 
@@ -73,6 +74,9 @@ class AccountAnalyticLineCase(SavepointCase):
         # Running line found, stop the timer
         self.assertEqual(self.lead.show_time_control, "stop")
         self.lead.button_end_work()
+        # No more running lines, cannot stop again
+        with self.assertRaises(exceptions.UserError):
+            self.lead.button_end_work()
         # All lines stopped, start new one
         self.lead.invalidate_cache()
         self.assertEqual(self.lead.show_time_control, "start")


### PR DESCRIPTION
Imagine this scenario:

1. In tab 1 of the browser, you have opened lead 1.
2. In tab 2 of the browser, you have opened lead 2.
3. You go to tab 1 and start a timer.
4. Work, work, work...
5. You go to tab 2 and start a timer, stopping that of lead 1.
6. Work, work, work...
7. You go to tab 1 and see that timer as running (it is not, but you didn't refresh). You hit stop.

Before this commit, it just seemed like the timer was actually stopped. What did happen behind the scenes is that your view was refreshed, but no timer was touched fortunately.

After this commit, you get a message telling you that there's no timer to stop and that your browser is most likely out of sync. This mimics the behavior previously found when doing the same, but directly in the AAL. Now it's present in leads too.

@Tecnativa TT19205 https://github.com/OCA/project/pull/596