### PR TITLE
[12.0][IMP] hr_timesheet_role, hr_timesheet_sheet_role: validations moved to project_role

### DIFF
--- a/hr_timesheet_role/__manifest__.py
+++ b/hr_timesheet_role/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Task Logs by Role',
-    'version': '12.0.1.0.1',
+    'version': '12.0.2.0.0',
     'category': 'Human Resources',
     'website': 'https://github.com/OCA/hr-timesheet',
     'author':

--- a/hr_timesheet_role/models/project_project.py
+++ b/hr_timesheet_role/models/project_project.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Brainbean Apps (https://brainbeanapps.com)
+# Copyright 2018-2019 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models, api
@@ -11,12 +11,6 @@ class ProjectProject(models.Model):
         string='Timesheet Role Required',
         default=lambda self: self._default_is_timesheet_role_required(),
     )
-    limit_timesheet_role_to_assignments = fields.Boolean(
-        string='Limit Timesheet Role to Assignments',
-        default=(
-            lambda self: self._default_limit_timesheet_role_to_assignments()
-        ),
-    )
 
     @api.model
     def _default_is_timesheet_role_required(self):
@@ -24,13 +18,6 @@ class ProjectProject(models.Model):
             self._context.get('company_id', self.env.user.company_id.id)
         )
         return company.is_timesheet_role_required
-
-    @api.model
-    def _default_limit_timesheet_role_to_assignments(self):
-        company = self.env['res.company'].browse(
-            self._context.get('company_id', self.env.user.company_id.id)
-        )
-        return company.limit_timesheet_role_to_assignments
 
     @api.model
     def create(self, values):
@@ -41,11 +28,6 @@ class ProjectProject(models.Model):
         if company and 'is_timesheet_role_required' not in values:
             values['is_timesheet_role_required'] = (
                 company.is_timesheet_role_required
-            )
-
-        if company and 'limit_timesheet_role_to_assignments' not in values:
-            values['limit_timesheet_role_to_assignments'] = (
-                company.limit_timesheet_role_to_assignments
             )
 
         return super().create(values)

--- a/hr_timesheet_role/models/res_company.py
+++ b/hr_timesheet_role/models/res_company.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Brainbean Apps (https://brainbeanapps.com)
+# Copyright 2018-2019 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -10,8 +10,4 @@ class ResCompany(models.Model):
     is_timesheet_role_required = fields.Boolean(
         string='Timesheet Role Required',
         default=True,
-    )
-    limit_timesheet_role_to_assignments = fields.Boolean(
-        string='Limit Timesheet Role to Assignments',
-        default=False,
     )

--- a/hr_timesheet_role/models/res_config_settings.py
+++ b/hr_timesheet_role/models/res_config_settings.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Brainbean Apps (https://brainbeanapps.com)
+# Copyright 2018-2019 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -9,9 +9,5 @@ class ResConfigSettings(models.TransientModel):
 
     is_timesheet_role_required = fields.Boolean(
         related='company_id.is_timesheet_role_required',
-        readonly=False,
-    )
-    limit_timesheet_role_to_assignments = fields.Boolean(
-        related='company_id.limit_timesheet_role_to_assignments',
         readonly=False,
     )

--- a/hr_timesheet_role/views/project_project.xml
+++ b/hr_timesheet_role/views/project_project.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2018-2019 Brainbean Apps (https://brainbeanapps.com)
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
-    <!--
-        Copyright 2018 Brainbean Apps (https://brainbeanapps.com)
-        License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-    -->
 
     <record id="project_project_view_form_simplified" model="ir.ui.view">
         <field name="name">project.project.view.form.simplified.timetracker</field>
@@ -12,7 +12,6 @@
         <field name="arch" type="xml">
             <field name="allow_timesheets" position="after">
                 <field name="is_timesheet_role_required" attrs="{'invisible': [('allow_timesheets', '=', False)]}" string="Require role in Timesheets"/>
-                <field name="limit_timesheet_role_to_assignments" attrs="{'invisible': [('allow_timesheets', '=', False)]}"/>
             </field>
         </field>
     </record>
@@ -26,10 +25,6 @@
                 <div attrs="{'invisible': [('allow_timesheets', '=', False)]}">
                     <field name="is_timesheet_role_required" class="oe_inline"/>
                     <label for="is_timesheet_role_required" string="Require role in Timesheets"/>
-                </div>
-                <div attrs="{'invisible': [('allow_timesheets', '=', False)]}">
-                    <field name="limit_timesheet_role_to_assignments" class="oe_inline"/>
-                    <label for="limit_timesheet_role_to_assignments"/>
                 </div>
             </xpath>
         </field>

--- a/hr_timesheet_role/views/res_config_settings.xml
+++ b/hr_timesheet_role/views/res_config_settings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2018-2019 Brainbean Apps (https://brainbeanapps.com)
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
-    <!--
-        Copyright 2018 Brainbean Apps (https://brainbeanapps.com)
-        License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-    -->
 
     <record id="res_config_settings_view_form" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.hr_timesheet_timetracker</field>
@@ -21,18 +21,6 @@
                             <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
                             <div class="text-muted">
                                 Check to require role to be selected when using Timesheets.
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="limit_timesheet_role_to_assignments"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="limit_timesheet_role_to_assignments"/>
-                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                            <div class="text-muted">
-                                Check to limit role selection to current assignments only.
                             </div>
                         </div>
                     </div>

--- a/hr_timesheet_sheet_role/__manifest__.py
+++ b/hr_timesheet_sheet_role/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2018 Brainbean Apps (https://brainbeanapps.com)
+# Copyright 2018-2019 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'HR Timesheet Sheet by Role',
-    'version': '12.0.1.0.0',
+    'version': '12.0.2.0.0',
     'category': 'Human Resources',
     'website': 'https://github.com/OCA/hr-timesheet',
     'author':

--- a/hr_timesheet_sheet_role/tests/test_hr_timesheet_sheet_role.py
+++ b/hr_timesheet_sheet_role/tests/test_hr_timesheet_sheet_role.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Brainbean Apps (https://brainbeanapps.com)
+# Copyright 2018-2019 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from dateutil.relativedelta import relativedelta
@@ -15,37 +15,30 @@ class TestHrTimesheetRole(common.TransactionCase):
 
         self.now = fields.Datetime.now()
         self.Company = self.env['res.company']
-        self.SudoCompany = self.Company.sudo()
         self.Project = self.env['project.project']
-        self.SudoProject = self.Project.sudo()
         self.Role = self.env['project.role']
-        self.SudoRole = self.Role.sudo()
         self.HrEmployee = self.env['hr.employee']
-        self.SudoHrEmployee = self.HrEmployee.sudo()
         self.Assignment = self.env['project.assignment']
-        self.SudoAssignment = self.Assignment.sudo()
         self.AccountAnalyticLine = self.env['account.analytic.line']
-        self.SudoAccountAnalyticLine = self.AccountAnalyticLine.sudo()
         self.HrTimesheetSheet = self.env['hr_timesheet.sheet']
-        self.SudoHrTimesheetSheet = self.HrTimesheetSheet.sudo()
 
     def test_1(self):
-        project = self.SudoProject.create({
+        project = self.Project.create({
             'name': 'Project #1',
         })
-        role = self.SudoRole.create({
+        role = self.Role.create({
             'name': 'Role #1',
         })
-        employee = self.SudoHrEmployee.create({
+        employee = self.HrEmployee.create({
             'name': 'Employee #1',
             'user_id': self.env.user.id,
         })
-        self.SudoAssignment.create({
+        self.Assignment.create({
             'project_id': project.id,
             'role_id': role.id,
             'user_id': employee.user_id.id,
         })
-        sheet = self.SudoHrTimesheetSheet.create({
+        sheet = self.HrTimesheetSheet.create({
             'employee_id': employee.id,
         })
         sheet._onchange_scope()
@@ -69,28 +62,28 @@ class TestHrTimesheetRole(common.TransactionCase):
         self.assertEqual(len(sheet.line_ids), 0)
 
     def test_2(self):
-        company = self.SudoCompany.create({
+        company = self.Company.create({
             'name': 'Company #2',
             'is_timesheet_role_required': False,
-            'limit_timesheet_role_to_assignments': True,
+            'limit_role_to_assignments': True,
         })
-        project = self.SudoProject.create({
+        project = self.Project.create({
             'name': 'Project #2',
         })
-        role = self.SudoRole.create({
+        role = self.Role.create({
             'name': 'Role #2',
             'company_id': company.id,
         })
-        employee = self.SudoHrEmployee.create({
+        employee = self.HrEmployee.create({
             'name': 'Employee #2',
             'user_id': self.env.user.id,
         })
-        self.SudoAssignment.create({
+        self.Assignment.create({
             'project_id': project.id,
             'role_id': role.id,
             'user_id': employee.user_id.id,
         })
-        sheet = self.SudoHrTimesheetSheet.create({
+        sheet = self.HrTimesheetSheet.create({
             'employee_id': employee.id,
         })
         sheet._onchange_scope()
@@ -105,23 +98,23 @@ class TestHrTimesheetRole(common.TransactionCase):
             sheet.add_line_role_id = role
 
     def test_3(self):
-        project = self.SudoProject.create({
+        project = self.Project.create({
             'name': 'Project #3',
-            'limit_timesheet_role_to_assignments': True,
+            'limit_role_to_assignments': True,
         })
-        role = self.SudoRole.create({
+        role = self.Role.create({
             'name': 'Role #3',
         })
-        employee = self.SudoHrEmployee.create({
+        employee = self.HrEmployee.create({
             'name': 'Employee #3',
             'user_id': self.env.user.id,
         })
-        self.SudoAssignment.create({
+        self.Assignment.create({
             'project_id': project.id,
             'role_id': role.id,
             'user_id': employee.user_id.id,
         })
-        sheet = self.SudoHrTimesheetSheet.create({
+        sheet = self.HrTimesheetSheet.create({
             'employee_id': employee.id,
         })
         sheet._onchange_scope()


### PR DESCRIPTION
@pedrobaeza this one is related to https://github.com/OCA/project/pull/603, yet in this particular case I'm not sure how to better act as one field effectively gone from this module and went upstream. What to do with migration?