### PR TITLE
[10.0][FIX] hr_timesheet_holiday - user_id not correctly filled

### DIFF
--- a/hr_timesheet_holiday/models/hr_holidays.py
+++ b/hr_timesheet_holiday/models/hr_holidays.py
@@ -26,7 +26,9 @@ class HrHolidays(models.Model):
         projects = account.project_ids.filtered(
             lambda p: p.active is True)
         if not projects:
-            raise UserError('No active projects for this Analytic Account')
+            raise UserError(_('No active projects for this Analytic Account'))
+        # User exists because already checked during the action_approve
+        user = self.employee_id.user_id
         self.sudo().with_context(force_write=True).write(
             {'analytic_line_ids': [(0, False, {
                 'name': description,
@@ -35,6 +37,9 @@ class HrHolidays(models.Model):
                 'company_id': self.employee_id.company_id.id,
                 'account_id': account.id,
                 'project_id': projects[0].id,
+                # Due to the sudo(), we have to force the user here.
+                # Otherwise Odoo will put the Admin user as user_id.
+                'user_id': user.id,
             })]})
 
     @api.model

--- a/hr_timesheet_holiday/tests/test_all.py
+++ b/hr_timesheet_holiday/tests/test_all.py
@@ -81,7 +81,12 @@ class TimesheetHolidayTest(TestHrHolidaysBase):
         })
         hours_after = sum(account.line_ids.mapped('unit_amount'))
         self.assertEqual(hours_after - hours_before, 33.0)
-
+        # Ensure the user_id defined on generated analytic lines is the user
+        # set on the employee
+        user_employee = self.env['hr.employee'].browse(
+            self.employee_emp_id).user_id
+        self.assertTrue(user_employee)
+        self.assertEqual(account.line_ids.mapped("user_id"), user_employee)
         # Refuse leave and check hours removed from account
         leave.action_refuse()
         hours_final = sum(account.line_ids.mapped('unit_amount'))


### PR DESCRIPTION
**Current bug:**
During the generation of timesheet lines (`account.analytic.line`) related to the leave, the field `user_id` is not specified. And due to a `sudo()`, Odoo auto-fill it with the admin user.

**Expected behavior:**
This `user_id` field should be filled with the user related to the employee.

To use timesheet, every employees should have a related user_id. So raise an exception if the employee doesn't have a related user.