### PR TITLE
[9.0][hr_timesheet_activity_begin_end] migration to v9

### DIFF
--- a/hr_timesheet_activity_begin_end/__openerp__.py
+++ b/hr_timesheet_activity_begin_end/__openerp__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2015 Camptocamp SA (author: Guewen Baconnier)
-# © 2017 Martronic SA
+# Copyright 2015 Camptocamp SA (author: Guewen Baconnier)
+# Copyright 2017 Martronic SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {'name': 'Timesheet Activities - Begin/End Hours',

--- a/hr_timesheet_activity_begin_end/__openerp__.py
+++ b/hr_timesheet_activity_begin_end/__openerp__.py
@@ -1,36 +1,22 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Authors: Guewen Baconnier
-#    Copyright 2015 Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# © 2015 Camptocamp SA (author: Guewen Baconnier)
+# © 2017 Martronic SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {'name': 'Timesheet Activities - Begin/End Hours',
- 'version': '8.0.1.0.0',
- 'author': 'Camptocamp,Odoo Community Association (OCA)',
+ 'version': '9.0.1.0.0',
+ 'author': 'Camptocamp,Martronic SA,Odoo Community Association (OCA)',
  'license': 'AGPL-3',
  'category': 'Human Resources',
- 'depends': ['hr_timesheet_sheet',
-             ],
+ 'depends': [
+     'hr_timesheet_sheet',
+     'float_time_hms',
+     ],
  'website': 'http://www.camptocamp.com',
  'data': ['views/hr_analytic_timesheet.xml',
           'views/hr_timesheet_sheet.xml',
           ],
  'test': [],
- 'installable': False,
+ 'installable': True,
  'auto_install': False,
  }

--- a/hr_timesheet_activity_begin_end/__openerp__.py
+++ b/hr_timesheet_activity_begin_end/__openerp__.py
@@ -10,7 +10,6 @@
  'category': 'Human Resources',
  'depends': [
      'hr_timesheet_sheet',
-     'float_time_hms',
      ],
  'website': 'http://www.camptocamp.com',
  'data': ['views/hr_analytic_timesheet.xml',

--- a/hr_timesheet_activity_begin_end/i18n/hr_timesheet_activity_begin_end.pot
+++ b/hr_timesheet_activity_begin_end/i18n/hr_timesheet_activity_begin_end.pot
@@ -1,0 +1,72 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* hr_timesheet_activity_begin_end
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-04-27 07:47+0000\n"
+"PO-Revision-Date: 2015-04-27 07:47+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_timesheet_activity_begin_end
+#: field:hr.analytic.timesheet,aal_account_name:0
+msgid "Analytic Account Name"
+msgstr ""
+
+#. module: hr_timesheet_activity_begin_end
+#: model:ir.model,name:hr_timesheet_activity_begin_end.model_account_analytic_line
+msgid "Analytic Line"
+msgstr ""
+
+#. module: hr_timesheet_activity_begin_end
+#: field:hr.analytic.timesheet,aal_time_start:0
+#: field:hr.analytic.timesheet,aal_time_stop:0
+msgid "Analytic Line Begin Hour"
+msgstr ""
+
+#. module: hr_timesheet_activity_begin_end
+#: field:hr.analytic.timesheet,aal_date:0
+msgid "Analytic Line Date"
+msgstr ""
+
+#. module: hr_timesheet_activity_begin_end
+#: field:account.analytic.line,time_start:0
+msgid "Begin Hour"
+msgstr ""
+
+#. module: hr_timesheet_activity_begin_end
+#: field:account.analytic.line,time_stop:0
+msgid "End Hour"
+msgstr ""
+
+#. module: hr_timesheet_activity_begin_end
+#: code:addons/hr_timesheet_activity_begin_end/models/account_analytic_line.py:86
+#, python-format
+msgid "Lines can't overlap:\n"
+""
+msgstr ""
+
+#. module: hr_timesheet_activity_begin_end
+#: code:addons/hr_timesheet_activity_begin_end/models/account_analytic_line.py:54
+#, python-format
+msgid "The beginning hour (%s) must precede the ending hour (%s)."
+msgstr ""
+
+#. module: hr_timesheet_activity_begin_end
+#: code:addons/hr_timesheet_activity_begin_end/models/account_analytic_line.py:63
+#, python-format
+msgid "The duration (%s) must be equal to the difference between the hours (%s)."
+msgstr ""
+
+#. module: hr_timesheet_activity_begin_end
+#: model:ir.model,name:hr_timesheet_activity_begin_end.model_hr_analytic_timesheet
+msgid "Timesheet Line"
+msgstr ""
+

--- a/hr_timesheet_activity_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_activity_begin_end/models/account_analytic_line.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Authors: Guewen Baconnier
-#    Copyright 2015 Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# Copyright 2015 Camptocamp SA (author: Guewen Baconnier)
+# Copyright 2017 Martronic SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from __future__ import division
 
@@ -40,13 +24,15 @@ def float_time_convert(float_val):
 
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
+    _order = 'date desc, time_start desc, time_stop desc, id desc'
 
     time_start = fields.Float(string='Begin Hour')
     time_stop = fields.Float(string='End Hour')
 
-    @api.one
+    @api.multi
     @api.constrains('time_start', 'time_stop', 'unit_amount')
     def _check_time_start_stop(self):
+        self.ensure_one()
         start = timedelta(hours=self.time_start)
         stop = timedelta(hours=self.time_stop)
         if stop < start:
@@ -83,39 +69,6 @@ class AccountAnalyticLine(models.Model):
                                       lambda l: l.time_start
                                   )])
             raise exceptions.ValidationError(message)
-
-
-class HrAnalyticTimesheet(models.Model):
-    _inherit = 'hr.analytic.timesheet'
-
-    _order = "id desc"
-    _order = ("aal_date DESC, aal_time_start DESC,"
-              "aal_time_stop DESC, aal_account_name ASC")
-
-    aal_date = fields.Date(
-        string='Analytic Line Date',
-        related='line_id.date',
-        store=True,
-        readonly=True,
-    )
-    aal_time_start = fields.Float(
-        string='Analytic Line Begin Hour',
-        related='line_id.time_start',
-        store=True,
-        readonly=True,
-    )
-    aal_time_stop = fields.Float(
-        string='Analytic Line Begin Hour',
-        related='line_id.time_stop',
-        store=True,
-        readonly=True,
-    )
-    aal_account_name = fields.Char(
-        string='Analytic Account Name',
-        related='account_id.name',
-        store=True,
-        readonly=True,
-    )
 
     @api.onchange('time_start', 'time_stop')
     def onchange_hours_start_stop(self):

--- a/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
+++ b/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
@@ -6,8 +6,8 @@
       <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
       <field name="arch" type="xml">
         <field name="unit_amount" position="before">
-          <field name="time_start" widget="float_time_hms"/>
-          <field name="time_stop" widget="float_time_hms"/>
+          <field name="time_start" widget="float_time"/>
+          <field name="time_stop" widget="float_time"/>
         </field>
       </field>
     </record>
@@ -18,8 +18,8 @@
       <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form"/>
       <field name="arch" type="xml">
         <xpath expr="//field[@name='product_id']"  position="after">
-          <field name="time_start" widget="float_time_hms"/>
-          <field name="time_stop" widget="float_time_hms"/>
+          <field name="time_start" widget="float_time"/>
+          <field name="time_stop" widget="float_time"/>
         </xpath>
       </field>
     </record>

--- a/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
+++ b/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
@@ -1,29 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-  <data>
     <record id="hr_timesheet_line_tree" model="ir.ui.view">
       <field name="name">hr.analytic.timesheet.tree</field>
-      <field name="model">hr.analytic.timesheet</field>
+      <field name="model">account.analytic.line</field>
       <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
       <field name="arch" type="xml">
         <field name="unit_amount" position="before">
-          <field name="time_start" widget="float_time"/>
-          <field name="time_stop" widget="float_time"/>
+          <field name="time_start" widget="float_time_hms"/>
+          <field name="time_stop" widget="float_time_hms"/>
         </field>
       </field>
     </record>
 
     <record id="hr_timesheet_line_form" model="ir.ui.view">
       <field name="name">hr.analytic.timesheet.form</field>
-      <field name="model">hr.analytic.timesheet</field>
+      <field name="model">account.analytic.line</field>
       <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form"/>
       <field name="arch" type="xml">
-        <xpath expr="//field[@name='unit_amount']/.."  position="before">
-          <field name="time_start" widget="float_time"/>
-          <field name="time_stop" widget="float_time"/>
+        <xpath expr="//field[@name='product_id']"  position="after">
+          <field name="time_start" widget="float_time_hms"/>
+          <field name="time_stop" widget="float_time_hms"/>
         </xpath>
       </field>
     </record>
-
-  </data>
 </openerp>

--- a/hr_timesheet_activity_begin_end/views/hr_timesheet_sheet.xml
+++ b/hr_timesheet_activity_begin_end/views/hr_timesheet_sheet.xml
@@ -7,12 +7,12 @@
       <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_form"/>
       <field name="arch" type="xml">
         <xpath expr="//field[@name='timesheet_ids']/tree/field[@name='unit_amount']" position="before">
-          <field name="time_start" widget="float_time_hms"/>
-          <field name="time_stop" widget="float_time_hms"/>
+          <field name="time_start" widget="float_time"/>
+          <field name="time_stop" widget="float_time"/>
         </xpath>
         <xpath expr="//field[@name='timesheet_ids']/form/group/field[@name='unit_amount']" position="before">
-          <field name="time_start" widget="float_time_hms"/>
-          <field name="time_stop" widget="float_time_hms"/>
+          <field name="time_start" widget="float_time"/>
+          <field name="time_stop" widget="float_time"/>
         </xpath>
       </field>
     </record>

--- a/hr_timesheet_activity_begin_end/views/hr_timesheet_sheet.xml
+++ b/hr_timesheet_activity_begin_end/views/hr_timesheet_sheet.xml
@@ -7,12 +7,12 @@
       <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_form"/>
       <field name="arch" type="xml">
         <xpath expr="//field[@name='timesheet_ids']/tree/field[@name='unit_amount']" position="before">
-          <field name="time_start" widget="float_time"/>
-          <field name="time_stop" widget="float_time"/>
+          <field name="time_start" widget="float_time_hms"/>
+          <field name="time_stop" widget="float_time_hms"/>
         </xpath>
-        <xpath expr="//field[@name='timesheet_ids']/form/field[@name='unit_amount']" position="before">
-          <field name="time_start" widget="float_time"/>
-          <field name="time_stop" widget="float_time"/>
+        <xpath expr="//field[@name='timesheet_ids']/form/group/field[@name='unit_amount']" position="before">
+          <field name="time_start" widget="float_time_hms"/>
+          <field name="time_stop" widget="float_time_hms"/>
         </xpath>
       </field>
     </record>


### PR DESCRIPTION
model hr.analytic.timesheet has been removed so we have moved functions to account.analytic.line and changed model of related views.
Same as https://github.com/OCA/timesheet/pull/96
But with right author.
