### PR TITLE
[12.0][FIX] hr_timesheet_sheet_policy*: admin always reviewer

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -11,7 +11,7 @@ from datetime import datetime, time
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import MONTHLY, WEEKLY
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
@@ -366,9 +366,10 @@ class Sheet(models.Model):
     @api.multi
     def _get_possible_reviewers(self):
         self.ensure_one()
+        res = self.env['res.users'].browse(SUPERUSER_ID)
         if self.review_policy == 'hr':
-            return self.env.ref('hr.group_hr_user').users
-        return self.env['res.users']
+            res |= self.env.ref('hr.group_hr_user').users
+        return res
 
     @api.multi
     def _get_timesheet_sheet_company(self):

--- a/hr_timesheet_sheet_policy_department_manager/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_policy_department_manager/models/hr_timesheet_sheet.py
@@ -54,9 +54,10 @@ class HrTimesheetSheet(models.Model):
     @api.multi
     def _get_possible_reviewers(self):
         self.ensure_one()
+        res = super()._get_possible_reviewers()
         if self.review_policy == 'department_manager':
-            return self.department_id.manager_id.user_id
-        return super()._get_possible_reviewers()
+            res |= self.department_id.manager_id.user_id
+        return res
 
     @api.multi
     def _check_can_review(self):

--- a/hr_timesheet_sheet_policy_direct_manager/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_policy_direct_manager/models/hr_timesheet_sheet.py
@@ -16,9 +16,10 @@ class HrTimesheetSheet(models.Model):
     @api.multi
     def _get_possible_reviewers(self):
         self.ensure_one()
+        res = super()._get_possible_reviewers()
         if self.review_policy == 'direct_manager':
-            return self.employee_id.parent_id.user_id
-        return super()._get_possible_reviewers()
+            res |= self.employee_id.parent_id.user_id
+        return res
 
     @api.multi
     def _check_can_review(self):

--- a/hr_timesheet_sheet_policy_project_manager/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_policy_project_manager/models/hr_timesheet_sheet.py
@@ -66,9 +66,10 @@ class HrTimesheetSheet(models.Model):
     @api.multi
     def _get_possible_reviewers(self):
         self.ensure_one()
+        res = super()._get_possible_reviewers()
         if self.review_policy == 'project_manager':
-            return self.project_id.user_id
-        return super()._get_possible_reviewers()
+            res |= self.project_id.user_id
+        return res
 
     @api.multi
     def _get_timesheet_sheet_lines_domain(self):


### PR DESCRIPTION
Admin user should be always able to review (refuse/reset to draft) any timesheet sheet.