### PR TITLE
[12.0][FIX] hr_timesheet_activity_begin_end: error on merge timesheet sheet lines

### DIFF
--- a/hr_timesheet_activity_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_activity_begin_end/models/account_analytic_line.py
@@ -62,3 +62,10 @@ class AccountAnalyticLine(models.Model):
         if stop < start:
             return
         self.unit_amount = (stop - start).seconds / 3600
+
+    def merge_timesheets(self):  # pragma: no cover
+        """This method is needed in case hr_timesheet_sheet is installed"""
+        lines = self.filtered(lambda l: not l.time_start and not l.time_stop)
+        if lines:
+            return super(AccountAnalyticLine, lines).merge_timesheets()
+        return self[0]

--- a/hr_timesheet_activity_begin_end/readme/CONTRIBUTORS.rst
+++ b/hr_timesheet_activity_begin_end/readme/CONTRIBUTORS.rst
@@ -3,3 +3,7 @@
 
   * Luis M. Ontalba
   * Ernesto Tejeda
+
+* `Onestein <https://www.onestein.eu>`_:
+
+  * Andrea Stirpe


### PR DESCRIPTION
This PR fixes a conflict with module `hr_timesheet_sheet`.
When `hr_timesheet_sheet` is installed, an error occurs by doing the following:

- In a timesheet sheet, create a line with Description = "/"
- Create another line with same project, task and description
- On both lines set Begin Hour and End Hour
- Save. An error will be displayed.

