### PR TITLE
[12.0][IMP] hr_timesheet_activity_begin_end: sort timesheets by date and time

### DIFF
--- a/hr_timesheet_activity_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_activity_begin_end/models/account_analytic_line.py
@@ -10,6 +10,7 @@ from odoo.tools.float_utils import float_compare
 
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
+    _order = 'date desc, time_start desc, id desc'
 
     time_start = fields.Float(string='Begin Hour')
     time_stop = fields.Float(string='End Hour')

--- a/hr_timesheet_activity_begin_end/views/hr_timesheet_sheet.xml
+++ b/hr_timesheet_activity_begin_end/views/hr_timesheet_sheet.xml
@@ -6,6 +6,9 @@
         <field name="inherit_id"
             ref="hr_timesheet_sheet.hr_timesheet_sheet_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
+                <attribute name="default_order">date, time_start, id</attribute>
+            </xpath>
             <xpath
                expr="//field[@name='timesheet_ids']/tree/field[@name='unit_amount']"
                position="before">


### PR DESCRIPTION
With this change, the timesheets are sorted not only by date but also by time.
This way it's possible to get an overview on the workday.
