### PR TITLE
[12.0][IMP] hr_timesheet_sheet_policy_direct_manager: top manager as reviewer

### DIFF
--- a/hr_timesheet_sheet_policy_direct_manager/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_policy_direct_manager/models/hr_timesheet_sheet.py
@@ -18,7 +18,11 @@ class HrTimesheetSheet(models.Model):
         self.ensure_one()
         res = super()._get_possible_reviewers()
         if self.review_policy == 'direct_manager':
-            res |= self.employee_id.parent_id.user_id
+            if self.employee_id.parent_id:
+                res |= self.employee_id.parent_id.user_id
+            elif self.employee_id.child_ids:
+                # A top Manager can approve his own timesheet sheets
+                res |= self.employee_id.user_id
         return res
 
     @api.multi

--- a/hr_timesheet_sheet_policy_direct_manager/readme/CONTRIBUTORS.rst
+++ b/hr_timesheet_sheet_policy_direct_manager/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Alexey Pelykh <alexey.pelykh@brainbeanapps.com>
+* Andrea Stirpe <a.stirpe@onestein.nl>

--- a/hr_timesheet_sheet_policy_direct_manager/readme/DESCRIPTION.rst
+++ b/hr_timesheet_sheet_policy_direct_manager/readme/DESCRIPTION.rst
@@ -1,1 +1,4 @@
-This module allows setting Direct Manager as Reviewer on Timesheet Sheets.
+This module allows to set the Direct Manager as Reviewer on Timesheet Sheets.
+
+The Manager with a top role in the organizational chart (no higher managers)
+is the Reviewer of own Timesheet Sheets.


### PR DESCRIPTION
The Manager with a top role in the organizational chart (no managers present in higher roles) should be the Reviewer of own Timesheet Sheets. Otherwise the workflow would be in a blocked state, as only admin could approve such timesheet sheets.
