### PR TITLE
[12.0][FIX] hr_timesheet_sheet: avoid clean/merge timesheets when not in draft

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -410,7 +410,8 @@ class Sheet(models.Model):
             for key in sorted(matrix,
                               key=lambda key: self._get_matrix_sortby(key)):
                 vals_list.append(sheet._get_default_sheet_line(matrix, key))
-                sheet.clean_timesheets(matrix[key])
+                if sheet.state in ['new', 'draft']:
+                    sheet.clean_timesheets(matrix[key])
             sheet.line_ids = SheetLine.create(vals_list)
 
     @api.model


### PR DESCRIPTION
In case for some reason the timesheet sheet is submitted while it still contains unmerged lines, when the manager tries to read the timesheet sheet, an error occurs:

```
  File "/opt/odoo/custom/addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py", line 737, in clean_timesheets
    return timesheets
  File "/opt/odoo/custom/addons/hr_timesheet_activity_begin_end/models/account_analytic_line.py", line 70, in merge_timesheets
    if lines:
  File "/opt/odoo/custom/addons/hr_timesheet_sheet/models/account_analytic_line.py", line 150, in merge_timesheets
    'amount': amount,
  File "/opt/odoo/odoo-server/addons/sale_timesheet/models/account.py", line 61, in write
    result = super(AccountAnalyticLine, self).write(values)
  File "/opt/odoo/odoo-server/addons/sale/models/analytic.py", line 28, in write
    result = super(AccountAnalyticLine, self).write(values)
  File "/opt/odoo/custom/addons/hr_timesheet_sheet/models/account_analytic_line.py", line 81, in write
    self._check_state_on_write(values)
  File "/opt/odoo/custom/addons/hr_timesheet_sheet/models/account_analytic_line.py", line 96, in _check_state_on_write
    self._check_state()
  File "/opt/odoo/custom/addons/hr_timesheet_sheet/models/account_analytic_line.py", line 140, in _check_state
    line.sheet_id.complete_name,
TypeError: not all arguments converted during string formatting
```

In this case, the error was caused by the code as proposed in https://github.com/OCA/timesheet/pull/304. But it could happen in any other case when the lines are not merged and the timesheet sheet submitted. We should prevent the clean/merge timesheets lines when timesheet sheets are not in draft.
