### PR TITLE
[FIX] hr_timesheet_sheet: same week in different years is still same

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -8,7 +8,7 @@ import logging
 import re
 from collections import namedtuple
 from datetime import datetime, time
-from dateutil.relativedelta import relativedelta
+from dateutil.relativedelta import relativedelta, SU
 from dateutil.rrule import MONTHLY, WEEKLY
 
 from odoo import api, fields, models, SUPERUSER_ID, _
@@ -221,14 +221,12 @@ class Sheet(models.Model):
                 '%V, %Y'
             )
 
-            if period_start == period_end:
-                sheet.name = '%s %s' % (
-                    _('Week'),
-                    period_start,
+            if sheet.date_end <= sheet.date_start + relativedelta(weekday=SU):
+                sheet.name = _('Week %s') % (
+                    period_end,
                 )
             else:
-                sheet.name = '%s %s - %s' % (
-                    _('Weeks'),
+                sheet.name = _('Weeks %s - %s') % (
                     period_start,
                     period_end,
                 )

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -3,6 +3,7 @@
 # Copyright 2018-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import date
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import MONTHLY, DAILY
 
@@ -1041,3 +1042,19 @@ class TestHrTimesheetSheet(TransactionCase):
         })
         self.assertEqual(sheet.review_policy, 'hr')
         sheet.unlink()
+
+    def test_same_week_different_years(self):
+        sheet = self.sheet_model.sudo(self.user).new({
+            'employee_id': self.employee.id,
+            'date_start': date(2019, 12, 30),
+            'date_end': date(2020, 1, 5),
+        })
+        self.assertEqual(sheet.name, 'Week 01, 2020')
+
+    def test_different_weeks_different_years(self):
+        sheet = self.sheet_model.sudo(self.user).new({
+            'employee_id': self.employee.id,
+            'date_start': date(2019, 12, 29),
+            'date_end': date(2020, 1, 5),
+        })
+        self.assertEqual(sheet.name, 'Weeks 52, 2019 - 01, 2020')


### PR DESCRIPTION
Previously it was

> Weeks 01, 2019 - 01, 2020

now

> Week 01, 2020

in accordance to ISO.