### PR TITLE
[12.0] hr_timesheet_sheet: fix FR translation that trigger a crash

### DIFF
--- a/hr_timesheet_sheet/i18n/fr.po
+++ b/hr_timesheet_sheet/i18n/fr.po
@@ -414,7 +414,7 @@ msgid ""
 "user: %s"
 msgstr ""
 "Pour créer une feuille de temps pour cet employé, vous devez lier l'employé "
-"à un utilisateur."
+"à un utilisateur: %s."
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:616
@@ -1037,7 +1037,7 @@ msgstr "Semaine"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:225
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semaine "
+msgstr "Semaine %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
@@ -1053,7 +1053,7 @@ msgstr ""
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:229
 #, fuzzy, python-format
 msgid "Weeks %s - %s"
-msgstr "Semaine "
+msgstr "Semaines %s - %s"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
@@ -1072,7 +1072,6 @@ msgid ""
 " - %s of %s\n"
 " - %s of %s"
 msgstr ""
-"Vous ne pouvez pas modifier une entrée dans une feuille de temps confirmée."
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:554
@@ -1081,7 +1080,7 @@ msgid ""
 "You cannot delete a timesheet sheet which is already submitted or confirmed: "
 "%s"
 msgstr ""
-"Vous ne pouvez pas supprimer des feuilles de temps qui sont déjà confirmées."
+"Vous ne pouvez pas supprimer une feuille de temps qui est déjà confirmée : %s"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:525
@@ -1099,14 +1098,15 @@ msgid ""
 " - %s"
 msgstr ""
 "Vous ne pouvez pas avoir 2 feuilles de temps qui se chevauchent!\n"
-"SVP utilisez le menu 'Ma feuille de temps actuelle' pour éviter ce problème."
+"SVP utilisez le menu 'Ma feuille de temps actuelle' pour éviter ce problème.\n"
+"Feuilles de temps en conflit :\n"
+" - %s"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
 #, fuzzy, python-format
 msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr ""
-"Vous ne pouvez pas modifier une entrée dans une feuille de temps confirmée."
+msgstr "Vous ne pouvez pas modifier une entrée dans une feuille de temps confirmée: %s."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my


### PR DESCRIPTION
Here is the crash:
```
2020-02-11 18:07:11,962 23580 ERROR demo2 odoo.http: Exception during JSON request handling. 
Traceback (most recent call last):
  File "/opt/odoo/v12/odoo/odoo/api.py", line 1049, in get
    value = self._data[key][field][record._ids[0]]
KeyError: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/v12/odoo/odoo/fields.py", line 1005, in __get__
    value = record.env.cache.get(record, self)
  File "/opt/odoo/v12/odoo/odoo/api.py", line 1051, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: ('hr_timesheet.sheet(1,).name', None)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/v12/odoo/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/v12/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/opt/odoo/v12/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/opt/odoo/v12/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/v12/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/v12/odoo/odoo/service/model.py", line 97, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/v12/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/v12/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/v12/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/v12/odoo/addons/web/controllers/main.py", line 904, in search_read
    return self.do_search_read(model, fields, offset, limit, domain, sort)
  File "/opt/odoo/v12/odoo/addons/web/controllers/main.py", line 926, in do_search_read
    offset=offset or 0, limit=limit or False, order=sort or False)
  File "/opt/odoo/v12/odoo/odoo/models.py", line 4603, in search_read
    result = records.read(fields)
  File "/opt/odoo/v12/odoo/odoo/models.py", line 2806, in read
    vals[name] = convert(record[name], record, use_name_get)
  File "/opt/odoo/v12/odoo/odoo/models.py", line 5131, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/opt/odoo/v12/odoo/odoo/fields.py", line 1009, in __get__
    self.determine_value(record)
  File "/opt/odoo/v12/odoo/odoo/fields.py", line 1122, in determine_value
    self.compute_value(recs)
  File "/opt/odoo/v12/odoo/odoo/fields.py", line 1076, in compute_value
    self._compute_value(records)
  File "/opt/odoo/v12/odoo/odoo/fields.py", line 1067, in _compute_value
    getattr(records, self.compute)()
  File "/opt/odoo/v12/hr-timesheet/hr_timesheet_sheet/models/hr_timesheet_sheet.py", line 207, in _compute_name
    period_end,
TypeError: not all arguments converted during string formatting
```