### PR TITLE
[FIX][11.0] hr_timesheet_task_stage: Make is_task_closed readonly

### DIFF
--- a/hr_timesheet_task_stage/models/account_analytic_line.py
+++ b/hr_timesheet_task_stage/models/account_analytic_line.py
@@ -13,6 +13,7 @@ class AccountAnalyticLine(models.Model):
 
     is_task_closed = fields.Boolean(
         related='task_id.stage_id.closed',
+        readonly=True,
     )
 
     @api.multi


### PR DESCRIPTION
This fix is required to avoid access rights issues, avoiding write in
related field from UI