### PR TITLE
[12.0][FIX] sale_timesheet_rounded: Copy fields even if they are an OrderedDict (odict_keys)

### DIFF
--- a/hr_timesheet_sheet/i18n/de.po
+++ b/hr_timesheet_sheet/i18n/de.po
@@ -1026,7 +1026,7 @@ msgstr "Woche"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Woche "
+msgstr "Woche %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
@@ -1042,7 +1042,7 @@ msgstr "Tag des Wochenstarts"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
 #, fuzzy, python-format
 msgid "Weeks %s - %s"
-msgstr "Woche "
+msgstr "Woche %s - %s"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/sale_timesheet_rounded/models/account_analytic_line.py
+++ b/sale_timesheet_rounded/models/account_analytic_line.py
@@ -146,7 +146,7 @@ class AccountAnalyticLine(models.Model):
         This affects `account_anaytic_line._sale_determine_order_line`.
         """
         ctx_ts_rounded = self.env.context.get('timesheet_rounding')
-        fields_local = fields.copy() if fields else []
+        fields_local = list(fields) if fields else []
         read_unit_amount = 'unit_amount' in fields_local or not fields_local
         if ctx_ts_rounded and read_unit_amount and fields_local:
             if 'unit_amount_rounded' not in fields_local:


### PR DESCRIPTION
```fields``` may be of type 'list', 'set' or 'odict_keys'. The problem comes with 'odict_keys' since it has no .copy() method (it's a shallow pointer to the OrderedDict) 

The simple solution to this would be to always convert ```fields``` to a 'list' but maybe this introduces problems later on if the type is changed?!?

Maybe there is a better solution that will not change 'odict_keys' or 'set' to a 'list'?