### PR TITLE
[12.0][FIX] hr_timesheet_sheet: drop fuzzy+python-format translations

### DIFF
--- a/hr_timesheet_sheet/i18n/af.po
+++ b/hr_timesheet_sheet/i18n/af.po
@@ -645,12 +645,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Tydstate"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""

--- a/hr_timesheet_sheet/i18n/ar.po
+++ b/hr_timesheet_sheet/i18n/ar.po
@@ -663,12 +663,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "خطوط سجل الدوام"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr "ابحث عن سجل الدوام"
@@ -1033,12 +1027,6 @@ msgid "Week"
 msgstr "الأسبوع"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "أسبوع"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1049,42 +1037,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "أسبوع"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "لا يمكنك تعديل مدخل في سجل حضور قد تمت الموافقة عليه"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "لا يمكنك حذف جدول زمني وقد تم تأكيده."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "لا يمكنك تكرار جدول زمني."
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
@@ -1095,12 +1053,6 @@ msgid ""
 "Conflicting sheets:\n"
 " - %s"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "لا يمكنك تعديل مدخل في سجل حضور قد تمت الموافقة عليه"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/bg.po
+++ b/hr_timesheet_sheet/i18n/bg.po
@@ -656,12 +656,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Дейности във времевите листове"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -1024,12 +1018,6 @@ msgid "Week"
 msgstr "Седмица"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Седмица"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1038,12 +1026,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Седмица"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/bs.po
+++ b/hr_timesheet_sheet/i18n/bs.po
@@ -655,12 +655,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Vremenski listovi"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -1025,12 +1019,6 @@ msgid "Week"
 msgstr "Sedmica"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Sedmica"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1039,12 +1027,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Sedmica"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/ca.po
+++ b/hr_timesheet_sheet/i18n/ca.po
@@ -418,26 +418,6 @@ msgid "In Draft"
 msgstr "En esborrany"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Per crear una part d'hores per aquest treballador, ha d'enllaçar-lo amb un "
-"usuari."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Per crear una part d'hores per aquest treballador, ha d'enllaçar-lo amb un "
-"usuari."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -667,12 +647,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Línies full de serveis"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1048,12 +1022,6 @@ msgid "Week"
 msgstr "Setmana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Setmana"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1064,61 +1032,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Setmana"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "No pot modificar una entrada en la fulla d'hores confirmades."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "No pot eliminar una fulla d'hores que ja està confirmada."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "No pot duplicar una fulla d'hores."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"No pot tenir 2 fulles d'hores que es solapen!\n"
-"Si us plau, utilitzi el menú 'La meva fulla d'hores' per evitar aquest "
-"problema."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "No pot modificar una entrada en la fulla d'hores confirmades."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/cs.po
+++ b/hr_timesheet_sheet/i18n/cs.po
@@ -655,12 +655,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Řádky výkazu"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr "Prohledej výkazy"
@@ -1028,12 +1022,6 @@ msgid "Week"
 msgstr "Týden"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Týden "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1042,12 +1030,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Týden "
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/da.po
+++ b/hr_timesheet_sheet/i18n/da.po
@@ -140,24 +140,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Kan ikke godkende en timeseddel der ikke er indsendt"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Kan ikke godkende en timeseddel der ikke er indsendt"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Kan ikke godkende en timeseddel der ikke er indsendt"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -412,26 +394,6 @@ msgid "In Draft"
 msgstr "I udkast status"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"For at oprette et tidsskema for denne medarbejder, skal du linke ham/hende "
-"til en bruger."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"For at oprette et tidsskema for denne medarbejder, skal du linke ham/hende "
-"til en bruger."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -661,12 +623,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Tidsskema linier"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1036,12 +992,6 @@ msgid "Week"
 msgstr "Uge"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Uge "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1052,60 +1002,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Uge "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Du kan ikke ændre en indtastning i et tidsskema der er bekræftet."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Du kan ikke slette et tidsskema, som allerede er godkendt."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Du kan ikke kopiere et tidsskema."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Du kan ikke have to tidsskemaer, der overlapper.\n"
-"Brug menuen \"mit aktuelle tidsskema\" for at undgå dette problem."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Du kan ikke ændre en indtastning i et tidsskema der er bekræftet."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/de.po
+++ b/hr_timesheet_sheet/i18n/de.po
@@ -1023,12 +1023,6 @@ msgid "Week"
 msgstr "Woche"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Woche "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr "Tag des Wochenstarts"
@@ -1037,12 +1031,6 @@ msgstr "Tag des Wochenstarts"
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr "Tag des Wochenstarts"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Woche "
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/el.po
+++ b/hr_timesheet_sheet/i18n/el.po
@@ -653,12 +653,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Γραμμές Φύλλου Xρόνου Eργασίας"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -1021,12 +1015,6 @@ msgid "Week"
 msgstr "Εβδομάδα"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Εβδομάδα"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1035,12 +1023,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Εβδομάδα"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/en_AU.po
+++ b/hr_timesheet_sheet/i18n/en_AU.po
@@ -972,12 +972,6 @@ msgid "Week"
 msgstr "Week"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Week "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -986,12 +980,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Week "
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/en_GB.po
+++ b/hr_timesheet_sheet/i18n/en_GB.po
@@ -649,12 +649,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Timesheet Activities"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 #, fuzzy
 msgid "Search Timesheet"
@@ -1015,12 +1009,6 @@ msgid "Week"
 msgstr "Week"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Week "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1029,12 +1017,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Week "
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/es_AR.po
+++ b/hr_timesheet_sheet/i18n/es_AR.po
@@ -649,12 +649,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Líneas hoja de servicios"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 #, fuzzy
 msgid "Search Timesheet"
@@ -1015,12 +1009,6 @@ msgid "Week"
 msgstr "Semana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semana "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1031,28 +1019,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Semana "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "No puede modificar una entrada en un parte de horas confirmado."
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
@@ -1077,12 +1049,6 @@ msgid ""
 "Conflicting sheets:\n"
 " - %s"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "No puede modificar una entrada en un parte de horas confirmado."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/es_CL.po
+++ b/hr_timesheet_sheet/i18n/es_CL.po
@@ -979,12 +979,6 @@ msgid "Week"
 msgstr "Semana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semana"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -993,12 +987,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Semana"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/es_CR.po
+++ b/hr_timesheet_sheet/i18n/es_CR.po
@@ -646,12 +646,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Líneas hoja de servicios"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr "Buscar hoja de asistencia"
@@ -1015,12 +1009,6 @@ msgid "Week"
 msgstr "Semana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semana"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1029,12 +1017,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Semana"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/es_EC.po
+++ b/hr_timesheet_sheet/i18n/es_EC.po
@@ -415,26 +415,6 @@ msgid "In Draft"
 msgstr "En borrador"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Para crear una Hoja de Registro para este empleado, debe enlazarlo con un "
-"usuario."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Para crear una Hoja de Registro para este empleado, debe enlazarlo con un "
-"usuario."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -664,12 +644,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Líneas de Hoja de registros"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1047,12 +1021,6 @@ msgid "Week"
 msgstr "Semana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semana "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1063,42 +1031,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Semana "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "No puede modificar una entrada en una Hoja de Registro confirmada."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "No puede eliminar una Hoja de Registro que ya está confirmada."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "No puede duplicar una Hoja de Registro."
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
@@ -1109,12 +1047,6 @@ msgid ""
 "Conflicting sheets:\n"
 " - %s"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "No puede modificar una entrada en una Hoja de Registro confirmada."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/es_PE.po
+++ b/hr_timesheet_sheet/i18n/es_PE.po
@@ -647,12 +647,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Actividades de Hoja de Tiempo"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 #, fuzzy
 msgid "Search Timesheet"
@@ -1009,12 +1003,6 @@ msgid "Week"
 msgstr "Semana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semana"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1023,12 +1011,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Semana"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/es_VE.po
+++ b/hr_timesheet_sheet/i18n/es_VE.po
@@ -645,12 +645,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Líneas hoja de servicios"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr "Buscar hoja de asistencia"
@@ -1010,12 +1004,6 @@ msgid "Week"
 msgstr "Semana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semana"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1024,12 +1012,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Semana"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/et.po
+++ b/hr_timesheet_sheet/i18n/et.po
@@ -657,12 +657,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Tööajalehe read"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -1025,12 +1019,6 @@ msgid "Week"
 msgstr "Nädal"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Nädal"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1039,12 +1027,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Nädal"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/eu.po
+++ b/hr_timesheet_sheet/i18n/eu.po
@@ -655,12 +655,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Denbora-orriak"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -1017,12 +1011,6 @@ msgid "Week"
 msgstr "Astea"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Astea"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1031,12 +1019,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Astea"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/fa.po
+++ b/hr_timesheet_sheet/i18n/fa.po
@@ -656,12 +656,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "فعالیتهای برگه کارکرد"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -1022,12 +1016,6 @@ msgid "Week"
 msgstr "هفته"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "هفته"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1036,12 +1024,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "هفته"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/fi.po
+++ b/hr_timesheet_sheet/i18n/fi.po
@@ -142,24 +142,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Hyväksyntään lähettämätöntä tuntikorttia ei voi hyväksyä."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Hyväksyntään lähettämätöntä tuntikorttia ei voi hyväksyä."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Hyväksyntään lähettämätöntä tuntikorttia ei voi hyväksyä."
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -420,26 +402,6 @@ msgid "In Draft"
 msgstr "Luonnoksena"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Luodaksesi tuntikortin tälle työntekijälle, sinun pitää kytkeä hänet Odoo "
-"käyttäjään. "
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Luodaksesi tuntikortin tälle työntekijälle, sinun pitää kytkeä hänet Odoo "
-"käyttäjään. "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -584,12 +546,6 @@ msgid "Number of unread messages"
 msgstr "Lukemattomat viestit"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr "Vain HR-johtaja tai -päällikkö voi hyväksyä tuntikortteja."
-
-#. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
 msgid "Open"
 msgstr "Avoin"
@@ -669,12 +625,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Tuntikortin rivit"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1050,12 +1000,6 @@ msgid "Week"
 msgstr "Viikko"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Viikko "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1066,61 +1010,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Viikko "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Et voi muuttaa vahvistetulla tuntikortilla olevaa tietoa."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Et voi poistaa jo vahvistettua tuntikorttia."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Et voi tuplata tuntikorttia."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Sinulla ei voi olla kahta päällekkäistä tuntikorttia!\n"
-"Käytä valikon valintaa \"Minun nykyinen tuntikorttini\" välttääksesi tämän "
-"päällekkäisyyden."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Et voi muuttaa vahvistetulla tuntikortilla olevaa tietoa."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/fr.po
+++ b/hr_timesheet_sheet/i18n/fr.po
@@ -153,24 +153,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Impossible d'approuver une feuille d'heure non transmise"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Impossible d'approuver une feuille d'heure non transmise"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Impossible d'approuver une feuille d'heure non transmise"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -433,26 +415,6 @@ msgid "In Draft"
 msgstr "A l'état \"Brouillon\""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Pour créer une feuille de temps pour cet employé, vous devez lier l'employé "
-"à un utilisateur: %s."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Pour créer une feuille de temps pour cet employé, vous devez lier l'employé "
-"à un utilisateur."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -682,12 +644,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Lignes des feuilles de temps"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1063,12 +1019,6 @@ msgid "Week"
 msgstr "Semaine"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semaine %s"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1080,7 +1030,7 @@ msgstr ""
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
+#, python-format
 msgid "Weeks %s - %s"
 msgstr "Semaines %s - %s"
 
@@ -1101,44 +1051,6 @@ msgid ""
 " - %s of %s\n"
 " - %s of %s"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr ""
-"Vous ne pouvez pas supprimer une feuille de temps qui est déjà confirmée : %s"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Vous ne pouvez pas dupliquer une feuille de temps."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Vous ne pouvez pas avoir 2 feuilles de temps qui se chevauchent!\n"
-"SVP utilisez le menu 'Ma feuille de temps actuelle' pour éviter ce "
-"problème.\n"
-"Feuilles de temps en conflit :\n"
-" - %s"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr ""
-"Vous ne pouvez pas modifier une entrée dans une feuille de temps confirmée: "
-"%s."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/gl.po
+++ b/hr_timesheet_sheet/i18n/gl.po
@@ -638,12 +638,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Follas de traballo"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -996,12 +990,6 @@ msgid "Week"
 msgstr "Semana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semana"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1010,12 +998,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Semana"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/gu.po
+++ b/hr_timesheet_sheet/i18n/gu.po
@@ -642,12 +642,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "સમય પત્રક"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""

--- a/hr_timesheet_sheet/i18n/he.po
+++ b/hr_timesheet_sheet/i18n/he.po
@@ -986,12 +986,6 @@ msgid "Week"
 msgstr "שבוע"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "שבוע"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1000,12 +994,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "שבוע"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/hr.po
+++ b/hr_timesheet_sheet/i18n/hr.po
@@ -423,26 +423,6 @@ msgid "In Draft"
 msgstr "U nacrtu"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Kako bi se kreirali evidenciju rada za ovog djelatnika, morate njega/nju "
-"vezati na korisnika."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Kako bi se kreirali evidenciju rada za ovog djelatnika, morate njega/nju "
-"vezati na korisnika."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -672,12 +652,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Stavke evidencije rada"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1053,12 +1027,6 @@ msgid "Week"
 msgstr "Tjedan"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Tjedan "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1069,61 +1037,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Tjedan "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Ne možete modificirati polje u potvrđenoj kontrolnoj kartici."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Ne možete obrisati evidenciju rada koja je već potvrđena."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Ne možete duplicirati evidenciju rada."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Ne možete imati 2 evidencije rada koje se preklapaju! \n"
-"Molimo koristite izbornik 'Moja trenutna evidencija rada' kako bi izbjegli "
-"ovaj problem."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Ne možete modificirati polje u potvrđenoj kontrolnoj kartici."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/hu.po
+++ b/hr_timesheet_sheet/i18n/hu.po
@@ -137,24 +137,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Nem lehet jóváhagyni egy beadatlan munkaidő-kiosztást."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Nem lehet jóváhagyni egy beadatlan munkaidő-kiosztást."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Nem lehet jóváhagyni egy beadatlan munkaidő-kiosztást."
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -419,26 +401,6 @@ msgid "In Draft"
 msgstr "Tervezet"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Ahhoz, hogy munkaidőbeosztás tudjon ennek a munkavállalónak készíteni, "
-"előszöz hozzá kell rendelnie egy felhasználóhoz."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Ahhoz, hogy munkaidőbeosztás tudjon ennek a munkavállalónak készíteni, "
-"előszöz hozzá kell rendelnie egy felhasználóhoz."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -583,14 +545,6 @@ msgid "Number of unread messages"
 msgstr "Olvasatlan üzenetek"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr ""
-"Csak egy HR emberi erőforrás hivatalnok vagy vezető tud jóváhagyni munkaidő-"
-"kiosztásokat."
-
-#. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
 msgid "Open"
 msgstr "Megnyitás"
@@ -672,12 +626,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Munkaidő-kiosztás sorok"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1055,12 +1003,6 @@ msgid "Week"
 msgstr "Hét"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Hét "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1071,61 +1013,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Hét "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Nem tud módosítani a visszaigazolt időkimutatáson."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Nem törölhet olyan időkimutatást, mely már visszaigazolt."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Nem többszörözhet egy időkimutatást."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Nem lehet 2 időkimutatása mely fedi egymást!\n"
-"Használja a 'Én aktuális időkimutatásom' menüt, ennek a problémának az "
-"elkerülésére."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Nem tud módosítani a visszaigazolt időkimutatáson."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/id.po
+++ b/hr_timesheet_sheet/i18n/id.po
@@ -415,26 +415,6 @@ msgid "In Draft"
 msgstr "Aliran masuk"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Dalam rangka menciptakan absen untuk karyawan ini, Anda harus menghubungkan "
-"dia / dia untuk pengguna."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Dalam rangka menciptakan absen untuk karyawan ini, Anda harus menghubungkan "
-"dia / dia untuk pengguna."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -664,12 +644,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Baris absen"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1039,12 +1013,6 @@ msgid "Week"
 msgstr "Pekan"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Pekan"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1055,60 +1023,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Pekan"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Anda tidak dapat memodifikasi entri dalam absen dikonfirmasi."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Anda tidak dapat menghapus absen yang sudah dikonfirmasi."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Anda tidak dapat menduplikasi kartu absen."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Anda tidak dapat memiliki 2 timesheets yang tumpang tindih! Silakan gunakan "
-"menu 'My Timesheet sekarang' untuk menghindari masalah ini."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Anda tidak dapat memodifikasi entri dalam absen dikonfirmasi."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/ja.po
+++ b/hr_timesheet_sheet/i18n/ja.po
@@ -140,24 +140,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "未提出のタイムシートを承認できません。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "未提出のタイムシートを承認できません。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "未提出のタイムシートを承認できません。"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -418,26 +400,6 @@ msgid "In Draft"
 msgstr "原案中"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"この従業員のタイムシートを作成するには、そのユーザを本人ととリンクさせる必要"
-"があります。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"この従業員のタイムシートを作成するには、そのユーザを本人ととリンクさせる必要"
-"があります。"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -582,12 +544,6 @@ msgid "Number of unread messages"
 msgstr "未読メッセージ"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr "HR担当者またはマネージャのみがタイムシートを承認できます。"
-
-#. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
 msgid "Open"
 msgstr "オープン"
@@ -667,12 +623,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "勤務表の行"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1048,12 +998,6 @@ msgid "Week"
 msgstr "週"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "週"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1064,42 +1008,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "週"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "確認済のタイムシート内のエントリは変更できません。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "既に承認済のタイムシートを削除することはできません。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "勤怠表を複製することはできません。"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
@@ -1110,12 +1024,6 @@ msgid ""
 "Conflicting sheets:\n"
 " - %s"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "確認済のタイムシート内のエントリは変更できません。"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/ka.po
+++ b/hr_timesheet_sheet/i18n/ka.po
@@ -648,12 +648,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "დროის აღრიცხვა"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -1010,12 +1004,6 @@ msgid "Week"
 msgstr "კვირა"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "კვირა"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1024,12 +1012,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "კვირა"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/kab.po
+++ b/hr_timesheet_sheet/i18n/kab.po
@@ -651,12 +651,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Izirigen n tiferkit n wakud"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr "Nadi tiferkit n wakud"
@@ -1017,12 +1011,6 @@ msgid "Week"
 msgstr "Dduṛt"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Dduṛt "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1033,42 +1021,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Dduṛt "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Asnifel n unekcam n tferkit n wakud intemen yegdel."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Tukksa n tferkit n wakud intemen tegdel."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Ur tezmireḍ ara a tselgeḍ tiferkit n wakud."
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
@@ -1079,12 +1037,6 @@ msgid ""
 "Conflicting sheets:\n"
 " - %s"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Asnifel n unekcam n tferkit n wakud intemen yegdel."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/ko.po
+++ b/hr_timesheet_sheet/i18n/ko.po
@@ -410,26 +410,6 @@ msgid "In Draft"
 msgstr "기안 상태"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"이 임직원에 대한 작업표를 작성하기 위해서는 사용자와 임직원을 연결해야 합니"
-"다."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"이 임직원에 대한 작업표를 작성하기 위해서는 사용자와 임직원을 연결해야 합니"
-"다."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -658,12 +638,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "작업표 명세"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1030,12 +1004,6 @@ msgid "Week"
 msgstr "주"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "주"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1046,60 +1014,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "주"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "확정된 작업표의 항목은 수정할 수 없습니다!"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "이미 확정된 작업표는 삭제할 수 없습니다."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "작업표를 복제할 수 없습니다."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"2개의 작업표를 동시에 띄울 수 없습니다!\n"
-"이 문제를 방지하려면 '개인 현재 작업표' 메뉴를 사용하십시오."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "확정된 작업표의 항목은 수정할 수 없습니다!"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/lt.po
+++ b/hr_timesheet_sheet/i18n/lt.po
@@ -143,24 +143,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Negalima patvirtinti nepateikto darbo apskaitos žiniaraščio."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Negalima patvirtinti nepateikto darbo apskaitos žiniaraščio."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Negalima patvirtinti nepateikto darbo apskaitos žiniaraščio."
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -415,26 +397,6 @@ msgid "In Draft"
 msgstr "Juodraštis"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Norint sukurti darbo laiko žiniaraštį šiam darbuotojui, Jūs privalote "
-"priskirti šį darbuotoją atitinkamui sistemos vartotojui."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Norint sukurti darbo laiko žiniaraštį šiam darbuotojui, Jūs privalote "
-"priskirti šį darbuotoją atitinkamui sistemos vartotojui."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -579,12 +541,6 @@ msgid "Number of unread messages"
 msgstr "Neskaityti pranešimai"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr "Tik "
-
-#. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
 msgid "Open"
 msgstr "Atverti"
@@ -664,12 +620,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Darbo laiko žiniaraščio eilutės"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1039,12 +989,6 @@ msgid "Week"
 msgstr "Savaitė"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Savaitę"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1055,66 +999,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Savaitę"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr ""
-"Jūs negalite modifkuoti įrašo, kuris yra patvirtintame darbo laiko "
-"žiniaraštyje."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr ""
-"Jūs negalite ištrinti darbo laiko žiniaraščio, kuris yra jau patvirtintas."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Jūs negalite duplikuoti darbo laiko žiniaraščio."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Jūs negalite turėti 2 darbo laiko žiniaraščių, kurie iš dalies sutampa!\n"
-"Prašome naudoti meniu \"Mano dabartinis darbo laiko žiniaraštis\", norint "
-"išvengti šios problemos."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr ""
-"Jūs negalite modifkuoti įrašo, kuris yra patvirtintame darbo laiko "
-"žiniaraštyje."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/lv.po
+++ b/hr_timesheet_sheet/i18n/lv.po
@@ -655,12 +655,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Darbu tabeles rindas"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr "Meklēt darbu tabeli"
@@ -1025,12 +1019,6 @@ msgid "Week"
 msgstr "Nedēļa"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Nedēļa "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1041,43 +1029,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Nedēļa "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Jūs nevarat mainīt ierakstu apstiprinātā darba uzskates tabelē."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr ""
-"Jūs nevarat izdzēst darbu uzskaites tabeli, kas jau ir stāvoklī apstiprināta."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Nevar dublēt darbu uzskates tabeli."
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
@@ -1088,12 +1045,6 @@ msgid ""
 "Conflicting sheets:\n"
 " - %s"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Jūs nevarat mainīt ierakstu apstiprinātā darba uzskates tabelē."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/mk.po
+++ b/hr_timesheet_sheet/i18n/mk.po
@@ -410,24 +410,6 @@ msgid "In Draft"
 msgstr "Во нацрт"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"За да креирате распоред за овој вработен мора до го/ја поврзете со корисник."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"За да креирате распоред за овој вработен мора до го/ја поврзете со корисник."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -657,12 +639,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Ставки на временска таблица"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1032,12 +1008,6 @@ msgid "Week"
 msgstr "Седмица"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Недела "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1048,42 +1018,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Недела "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Не можете да измените внес во потврдена временска таблица."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Не може да избришете временска таблица која е веќе потврдена."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Не може да дуплирате временски таблици."
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
@@ -1094,12 +1034,6 @@ msgid ""
 "Conflicting sheets:\n"
 " - %s"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Не можете да измените внес во потврдена временска таблица."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/mn.po
+++ b/hr_timesheet_sheet/i18n/mn.po
@@ -139,24 +139,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Илгээгээгүй цагийн хуудсыг зөвшөөрөх боломжгүй."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Илгээгээгүй цагийн хуудсыг зөвшөөрөх боломжгүй."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Илгээгээгүй цагийн хуудсыг зөвшөөрөх боломжгүй."
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -417,26 +399,6 @@ msgid "In Draft"
 msgstr "Ноорог"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Энэ ажилтан дээр цагийн хуудас үүсгэхийн тулд ажилтанг хэрэглэгчтэй холбох "
-"ёстой."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Энэ ажилтан дээр цагийн хуудас үүсгэхийн тулд ажилтанг хэрэглэгчтэй холбох "
-"ёстой."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -581,12 +543,6 @@ msgid "Number of unread messages"
 msgstr "Уншаагүй Зурвасууд"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr "Зөвхөн ХН Дарга эсвэл Менежер цагийн хуудсыг зөвшөөрөх эрхтэй."
-
-#. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
 msgid "Open"
 msgstr "Нээх"
@@ -666,12 +622,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Цагийн хуудасны мөрүүд"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1047,12 +997,6 @@ msgid "Week"
 msgstr "7 хоног"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "7 хоног "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1063,60 +1007,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "7 хоног "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Та баталгаажсан цагийн хуудсыг орж өөрчлөх боломжгүй."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Та аль хэдийн батлагдсан цагийн хуудас устгаж чадахгүй."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Та цагийн хуудсыг хувилбах боломжгүй."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Давхацсан 2 цагийн хуудастай байж болохгүй!\n"
-"'Өөрийн одоогийн цагийн хуудас' менюг ашигласнаар энэ асуудлаас зайлсхийнэ."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Та баталгаажсан цагийн хуудсыг орж өөрчлөх боломжгүй."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/nb.po
+++ b/hr_timesheet_sheet/i18n/nb.po
@@ -658,12 +658,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Timeliste-aktiviteter"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -1026,12 +1020,6 @@ msgid "Week"
 msgstr "Uke"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Uke"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1040,12 +1028,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Uke"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/nl_BE.po
+++ b/hr_timesheet_sheet/i18n/nl_BE.po
@@ -981,13 +981,6 @@ msgid "Week"
 msgstr "Week"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-#| msgid "Week"
-msgid "Week %s"
-msgstr "Week"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""

--- a/hr_timesheet_sheet/i18n/pl.po
+++ b/hr_timesheet_sheet/i18n/pl.po
@@ -142,24 +142,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Nie można aprobować nie przedstawionych kart pracy"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Nie można aprobować nie przedstawionych kart pracy"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Nie można aprobować nie przedstawionych kart pracy"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -414,26 +396,6 @@ msgid "In Draft"
 msgstr "Projekt"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Aby stworzyć kartę czasu pracy, dla tego pracownika, musisz do niego "
-"przypisać użytkownika."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Aby stworzyć kartę czasu pracy, dla tego pracownika, musisz do niego "
-"przypisać użytkownika."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -663,12 +625,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Pozycje karty czasu pracy"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1038,12 +994,6 @@ msgid "Week"
 msgstr "Tydzień"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Tydzień "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1054,60 +1004,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Tydzień "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Nie możesz modyfikować zapisów w potwierdzonej karcie pracy."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Nie możesz usuwać karty pracy, która jest już potwierdzona"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Nie można duplikować karty pracy."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Nie możesz mieć dwóch kart pracy zachodzących na siebie!\n"
-"Zastosuj menu 'Moje karty pracy', aby zapobiec temu."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Nie możesz modyfikować zapisów w potwierdzonej karcie pracy."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/pt.po
+++ b/hr_timesheet_sheet/i18n/pt.po
@@ -411,26 +411,6 @@ msgid "In Draft"
 msgstr "Em rascunho"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Para poder criar um registo de horas para este funcionário, deve associá-"
-"lo(a) a um utilizador."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Para poder criar um registo de horas para este funcionário, deve associá-"
-"lo(a) a um utilizador."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -660,12 +640,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Linhas do Registo de Horas"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1035,12 +1009,6 @@ msgid "Week"
 msgstr "Semana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semana "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1051,42 +1019,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Semana "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Não pode modificar um movimento num registo de horas confirmado."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Não pode eliminar um registo de horas que já foi confirmado."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Não pode duplicar um registo de horas."
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
@@ -1097,12 +1035,6 @@ msgid ""
 "Conflicting sheets:\n"
 " - %s"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Não pode modificar um movimento num registo de horas confirmado."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/pt_BR.po
+++ b/hr_timesheet_sheet/i18n/pt_BR.po
@@ -440,32 +440,6 @@ msgid "In Draft"
 msgstr "Rascunho"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-#| msgid ""
-#| "In order to create a sheet for this employee, you must link him/her to an "
-#| "user."
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Para criar uma planilha para este funcionário, você precisa conectar ele(a) "
-"a um usuário."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-#| msgid ""
-#| "In order to create a sheet for this employee, you must link him/her to an "
-#| "user."
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Para criar uma planilha para este funcionário, você precisa conectar ele(a) "
-"a um usuário."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr "É Seguidor"
@@ -604,13 +578,6 @@ msgstr "Número de mensagens com erro de entrega"
 #: model:ir.model.fields,help:hr_timesheet_sheet.field_hr_timesheet_sheet__message_unread_counter
 msgid "Number of unread messages"
 msgstr "Número de mensagens não lidas"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-#| msgid "Only an HR Officer or Manager can approve sheets."
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr "Apenas um Gerente ou Gerente de RH pode aprovar planilhas."
 
 #. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
@@ -1069,12 +1036,6 @@ msgid "Week"
 msgstr "Semana"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Semana "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr "Dia de Início da Semana"
@@ -1083,12 +1044,6 @@ msgstr "Dia de Início da Semana"
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr "Dia de início da semana"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Semana "
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
@@ -1100,57 +1055,10 @@ msgstr ""
 "Você não pode alterar a empresa, pois este %s (%s) está atribuído a %s (%s)."
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-#| msgid ""
-#| "You cannot create a timesheet of a different company than the one of the "
-#| "timesheet sheet."
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr ""
-"Você não pode criar uma planilha de horas de uma empresa diferente daquela "
-"da planilha de horas."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-#| msgid "You cannot delete a timesheet sheet which is already confirmed."
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Você não pode excluir uma planilha de horas que já foi confirmada."
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
 #, python-format
 msgid "You cannot duplicate a sheet."
 msgstr "Você não pode duplicar uma planilha de horas."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-#| msgid ""
-#| "You cannot have 2 sheets that overlap!\n"
-#| "Please use the menu 'Timesheet Sheet' to avoid this problem."
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Você não pode ter duas planilhas de horas que se sobrepõem!\n"
-"Você deve usar o menu 'Planilha de Horas' para evitar este problema."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-#| msgid "You cannot modify an entry in a confirmed timesheet sheet."
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr ""
-"Você não pode modificar um lançamento em uma planilha de horas confirmada."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/ro.po
+++ b/hr_timesheet_sheet/i18n/ro.po
@@ -657,12 +657,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Linii fisa de pontaj"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr "Cautati Fisa de pontaj"
@@ -1030,12 +1024,6 @@ msgid "Week"
 msgstr "Săptămână"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Săptămână"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1046,61 +1034,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Săptămână"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Nu puteti modifica o inregistrare intr-o fisa de pontaj confirmata."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Nu puteti sterge o fisa de pontaj care este deja confirmata."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Nu puteti copia o fisa de pontaj."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Nu puteti avea 2 fise de pontaj care sa se suprapuna!\n"
-"Va rugam sa folositi meniul 'Fisa mea de pontaj Actuala' pentru a evita "
-"aceasta problema."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Nu puteti modifica o inregistrare intr-o fisa de pontaj confirmata."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/ru.po
+++ b/hr_timesheet_sheet/i18n/ru.po
@@ -145,24 +145,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Нельзя одобрить неподтверждённый табель."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Нельзя одобрить неподтверждённый табель."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Нельзя одобрить неподтверждённый табель."
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -425,26 +407,6 @@ msgid "In Draft"
 msgstr "Черновик"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"В целях создания табеля для этого сотрудника, вам необходимо связать его/её "
-"с пользователем."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"В целях создания табеля для этого сотрудника, вам необходимо связать его/её "
-"с пользователем."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -589,12 +551,6 @@ msgid "Number of unread messages"
 msgstr "Непрочитанные Сообщения"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr "Только сотрудник по кадрам или менеджер могут утверждать табеля."
-
-#. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
 msgid "Open"
 msgstr "Открыть"
@@ -674,12 +630,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Строки табеля"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1055,12 +1005,6 @@ msgid "Week"
 msgstr "Неделя"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Неделя "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1071,61 +1015,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Неделя "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Вы не можете изменить запись в утверждённом табеле."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Вы не можете удалить уже подтверждённый табель."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Вы не можете дублировать табель."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Вы не может иметь 2 табеля, которые перекрываются!\n"
-"Пожалуйста, используйте меню 'Мой текущий табель', чтобы избежать этой "
-"проблемы.."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Вы не можете изменить запись в утверждённом табеле."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/sk.po
+++ b/hr_timesheet_sheet/i18n/sk.po
@@ -417,26 +417,6 @@ msgid "In Draft"
 msgstr "V návrhu"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"V záujme vytvorenia časového rozvrhu pre tohto zamestnanca, je nutné ho / ju "
-"prepojiť  s užívateľom."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"V záujme vytvorenia časového rozvrhu pre tohto zamestnanca, je nutné ho / ju "
-"prepojiť  s užívateľom."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -666,12 +646,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Riadky časového rozvrhu"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1047,12 +1021,6 @@ msgid "Week"
 msgstr "Týždeň"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Týždeň"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1063,61 +1031,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Týždeň"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Nemôžete upraviť vstup v potvrdenom časovom rozvrhu."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Nemžete zmazať časový rozvrh ktorý už bol potvrdený."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Nemžete duplikovať časový rozvrh."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Nemôźete mať 2 časové rozvrhy ktoré sa prekrývajú!\n"
-"Prosím použite menu \"Môj aktuálny časový rozvrh\" aby ste sa vyhli tomuto "
-"problému."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Nemôžete upraviť vstup v potvrdenom časovom rozvrhu."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/sl.po
+++ b/hr_timesheet_sheet/i18n/sl.po
@@ -410,24 +410,6 @@ msgid "In Draft"
 msgstr "V osnutku"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Delojemalec mora biti povezan z uporabnikom, da se lahko ustvari časovnica."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Delojemalec mora biti povezan z uporabnikom, da se lahko ustvari časovnica."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -656,12 +638,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Postavke časovnice"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1028,12 +1004,6 @@ msgid "Week"
 msgstr "Teden"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Teden "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1044,60 +1014,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Teden "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Vnosov v potrjeno časovnico ni mogoče spreminjati."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Potrjene časovnice ne morete izbrisati."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Časovnice ne morete podvojiti"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Dveh prekrivajočih se časovnic ne morete imeti!\n"
-"Uporabite meni 'Moje tekoče časovnice' v izogib temu problemu."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Vnosov v potrjeno časovnico ni mogoče spreminjati."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/sr@latin.po
+++ b/hr_timesheet_sheet/i18n/sr@latin.po
@@ -647,12 +647,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Karneti ( vremena rada)"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr ""
@@ -1013,12 +1007,6 @@ msgid "Week"
 msgstr "Nedelja"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Nedelja"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1027,12 +1015,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Nedelja"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/sv.po
+++ b/hr_timesheet_sheet/i18n/sv.po
@@ -415,26 +415,6 @@ msgid "In Draft"
 msgstr "Som utkast"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Den anställde måste vara knuten till en användare för att kunna "
-"tidrapportera."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Den anställde måste vara knuten till en användare för att kunna "
-"tidrapportera."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -664,12 +644,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Tidrapportrader"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1036,12 +1010,6 @@ msgid "Week"
 msgstr "Vecka"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Vecka"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1052,60 +1020,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Vecka"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Du kan inte ändra en rad i en bekräftad tidrapport."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Du kan inte radera en bekräftad tidrapport"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Du kan inte duplicera en tidrapport."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Du kan inte ha överlappande tidrapporter!\n"
-"Använd menyn \"Min aktuella tidrapport\" för att undvika detta problem."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Du kan inte ändra en rad i en bekräftad tidrapport."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/th.po
+++ b/hr_timesheet_sheet/i18n/th.po
@@ -655,12 +655,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "รายการสมุดจดเวลาทำงาน"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr "ค้นหาสมุดจดเวลาทำงาน"
@@ -1028,12 +1022,6 @@ msgid "Week"
 msgstr "สัปดาห์"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "สัปดาห์ "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1042,12 +1030,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "สัปดาห์ "
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/tr.po
+++ b/hr_timesheet_sheet/i18n/tr.po
@@ -146,24 +146,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Gönderilmemiş Zaman Çizelgesi Onaylanamaz."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Gönderilmemiş Zaman Çizelgesi Onaylanamaz."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Gönderilmemiş Zaman Çizelgesi Onaylanamaz."
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -426,26 +408,6 @@ msgid "In Draft"
 msgstr "Taslak"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Bu çalışan için bir zaman çizelgesi oluşturmak için/onu bir kullanıcıya "
-"bağlamanız gerekir."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Bu çalışan için bir zaman çizelgesi oluşturmak için/onu bir kullanıcıya "
-"bağlamanız gerekir."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -590,12 +552,6 @@ msgid "Number of unread messages"
 msgstr "Okunmamış Mesajlar"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr "Sadece IK Yetkilisi veya Yöneticisi Zaman Çizelgesini Onaylayabilir"
-
-#. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
 msgid "Open"
 msgstr "Aç"
@@ -675,12 +631,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Zaman Çizelgesi satırıları"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1058,12 +1008,6 @@ msgid "Week"
 msgstr "Hafta"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Hafta "
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1074,60 +1018,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Hafta "
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Onaylamış zaman çizelgesi bir girişi değiştiremezsiniz."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Onaylandıktan sonra bir zaman çizelgesini silemezsiniz."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Bir zaman çizelgesi çift olamaz."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Sen üst üste 2 zaman çizelgesi oluşturamazsın!\n"
-"Bu sorunu önlemek için menü'de 'Mevcut zaman çizelgesi' kullanın."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Onaylamış zaman çizelgesi bir girişi değiştiremezsiniz."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/uk.po
+++ b/hr_timesheet_sheet/i18n/uk.po
@@ -139,24 +139,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "Не вдається затвердити непредставлений табель."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "Не вдається затвердити непредставлений табель."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "Не вдається затвердити непредставлений табель."
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -419,26 +401,6 @@ msgid "In Draft"
 msgstr "В чорновому стані"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr ""
-"Щоб створити табель для цього співробітника, ви повинні зв'язати його з "
-"користувачем."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr ""
-"Щоб створити табель для цього співробітника, ви повинні зв'язати його з "
-"користувачем."
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -583,12 +545,6 @@ msgid "Number of unread messages"
 msgstr "Непрочитані повідомлення"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr "Тільки менеджер відділу кадрів може затвердити табель."
-
-#. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
 msgid "Open"
 msgstr "Відкрити"
@@ -668,12 +624,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Записи табелю"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1049,12 +999,6 @@ msgid "Week"
 msgstr "Тиждень"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Тиждень"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1065,60 +1009,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Тиждень"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "Ви не можете змінити запис на підтвердженому табелі."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "Ви не можете видалити табель, який повністю підтверджений."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "Ви не можете дублювати табель."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"Ви не можете мати 2 табелі, які перекриваються!\n"
-"Щоб уникнути цієї проблеми, скористайтеся меню \"Мій поточний табель\"."
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "Ви не можете змінити запис на підтвердженому табелі."
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/vi.po
+++ b/hr_timesheet_sheet/i18n/vi.po
@@ -655,12 +655,6 @@ msgid "Saturday"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "Hoạt động chấm công"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
 msgid "Search Timesheet"
 msgstr "Tìm kiếm Bảng chấm công"
@@ -1020,12 +1014,6 @@ msgid "Week"
 msgstr "Tuần"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "Tuần"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1034,12 +1022,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_company__timesheet_week_start
 msgid "Week start day"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "Tuần"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17

--- a/hr_timesheet_sheet/i18n/zh_CN.po
+++ b/hr_timesheet_sheet/i18n/zh_CN.po
@@ -410,22 +410,6 @@ msgid "In Draft"
 msgstr "在草稿"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr "要为员工创建工时表，你必须关联他/她到一个用户。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr "要为员工创建工时表，你必须关联他/她到一个用户。"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -655,12 +639,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "工时表明细"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1032,12 +1010,6 @@ msgid "Week"
 msgstr "周"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "周"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1048,60 +1020,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "周"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "你不能修改已确认的工时表的条目"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "你无法删除一张已确认的工时表。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "你无法复制工时表。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"您不能有2张重复的工时单！\n"
-"请使用菜单’我当前的工时单‘来避免这个问题。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "你不能修改已确认的工时表的条目"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my

--- a/hr_timesheet_sheet/i18n/zh_TW.po
+++ b/hr_timesheet_sheet/i18n/zh_TW.po
@@ -139,24 +139,6 @@ msgid "Can Review"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:579
-#, fuzzy, python-format
-msgid "Cannot approve a non-submitted sheet."
-msgstr "無法批准未提交的時間表。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:589
-#, fuzzy, python-format
-msgid "Cannot reject a non-submitted sheet."
-msgstr "無法批准未提交的時間表。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:563
-#, fuzzy, python-format
-msgid "Cannot revert to draft a non-approved sheet."
-msgstr "無法批准未提交的時間表。"
-
-#. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.res_config_settings_view_form
 msgid "Choose the week start day."
 msgstr ""
@@ -413,22 +395,6 @@ msgid "In Draft"
 msgstr "在草稿"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:494
-#, fuzzy, python-format
-msgid ""
-"In order to create a sheet for this employee, you must link him/her to an "
-"user: %s"
-msgstr "要為員工創建工時表，您必須關聯他/她到一個使用者。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:603
-#, fuzzy, python-format
-msgid ""
-"In order to review a timesheet sheet, your user needs to be linked to an "
-"employee."
-msgstr "要為員工創建工時表，您必須關聯他/她到一個使用者。"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__message_is_follower
 msgid "Is Follower"
 msgstr ""
@@ -573,12 +539,6 @@ msgid "Number of unread messages"
 msgstr "未讀消息"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:613
-#, fuzzy, python-format
-msgid "Only a HR Officer or Manager can review the sheet."
-msgstr "只有人力資源主管或經理可以批准時間表。"
-
-#. module: hr_timesheet_sheet
 #: selection:hr_timesheet.sheet,state:0
 msgid "Open"
 msgstr "打開"
@@ -658,12 +618,6 @@ msgstr ""
 #: selection:res.company,timesheet_week_start:0
 msgid "Saturday"
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:926
-#, fuzzy, python-format
-msgid "Save the Timesheet Sheet first."
-msgstr "工時表明細"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet_sheet.view_hr_timesheet_sheet_filter
@@ -1035,12 +989,6 @@ msgid "Week"
 msgstr "周"
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
-msgid "Week %s"
-msgstr "周"
-
-#. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
 msgid "Week Start Day"
 msgstr ""
@@ -1051,60 +999,12 @@ msgid "Week start day"
 msgstr ""
 
 #. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
-#, fuzzy, python-format
-msgid "Weeks %s - %s"
-msgstr "周"
-
-#. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17
 #: code:addons/hr_timesheet_sheet/models/hr_department.py:39
 #: code:addons/hr_timesheet_sheet/models/hr_employee.py:34
 #, python-format
 msgid "You cannot change the company, as this %s (%s) is assigned to %s (%s)."
 msgstr ""
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:59
-#, fuzzy, python-format
-msgid ""
-"You cannot create a timesheet of a different company than the one of the "
-"timesheet sheet:\n"
-" - %s of %s\n"
-" - %s of %s"
-msgstr "您不能修改已確認的工時表的條目"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:535
-#, fuzzy, python-format
-msgid ""
-"You cannot delete a timesheet sheet which is already submitted or confirmed: "
-"%s"
-msgstr "您無法刪除一張已確認的工時表。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:506
-#, fuzzy, python-format
-msgid "You cannot duplicate a sheet."
-msgstr "您無法複製工時表。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:300
-#, fuzzy, python-format
-msgid ""
-"You cannot have 2 or more sheets that overlap!\n"
-"Please use the menu \"Timesheet Sheet\" to avoid this problem.\n"
-"Conflicting sheets:\n"
-" - %s"
-msgstr ""
-"您不能有2個時間重疊的時間表！\n"
-"請使用選單“我當前的時間表”來避免這個問題。"
-
-#. module: hr_timesheet_sheet
-#: code:addons/hr_timesheet_sheet/models/account_analytic_line.py:136
-#, fuzzy, python-format
-msgid "You cannot modify an entry in a confirmed timesheet sheet: %s"
-msgstr "您不能修改已確認的工時表的條目"
 
 #. module: hr_timesheet_sheet
 #: model_terms:ir.actions.act_window,help:hr_timesheet_sheet.act_hr_timesheet_line_to_submit_my


### PR DESCRIPTION
Quite a messy PR about removing fuzzy + python-format translations, since that just gives errors