### PR TITLE
[FIX] hr_timesheet_sheet: %s missing in slovenian translation (sl.po).

### DIFF
--- a/hr_timesheet_sheet/i18n/sl.po
+++ b/hr_timesheet_sheet/i18n/sl.po
@@ -1032,7 +1032,7 @@ msgstr "Teden"
 #, fuzzy, python-format
 #| msgid "Week"
 msgid "Week %s"
-msgstr "Teden"
+msgstr "Teden %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start
@@ -1048,7 +1048,7 @@ msgstr ""
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:210
 #, python-format
 msgid "Weeks %s - %s"
-msgstr ""
+msgstr "Tedni %s - %s"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/account_analytic_account.py:17


### PR DESCRIPTION
Without this fix creating a new timesheet would raise an exception.

This is the same issue others had with other translations of this module. See: [https://github.com/OCA/timesheet/pull/339](url)


(I'm not sure if this is the correct way to address this issue since it's my first time contributing.)