### PR TITLE
[FIX] hr_timesheet_sheet_autodraft_project: add dependency on hr_timesheet_sheet_autodraft

### DIFF
--- a/hr_timesheet_sheet_autodraft_project/__manifest__.py
+++ b/hr_timesheet_sheet_autodraft_project/__manifest__.py
@@ -16,5 +16,6 @@
     'depends': [
         'hr_timesheet_sheet',
         'hr_timesheet_sheet_policy_project_manager',
+        'hr_timesheet_sheet_autodraft',
     ],
 }


### PR DESCRIPTION
The `hr_timesheet_sheet_autodraft_project` module does not function without the `hr_timesheet_sheet_autodraft` module. Also attempting to install the `hr_timesheet_sheet_autodraft_project` while the `hr_timesheet_sheet_autodraft` module is not installed causes unit tests to fail.