### PR TITLE
[FIX] hr_timesheet_activity_begin_end: fix false positives in constraint

### DIFF
--- a/hr_timesheet_activity_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_activity_begin_end/models/account_analytic_line.py
@@ -30,7 +30,10 @@ class AccountAnalyticLine(models.Model):
                     )
                 )
             hours = (stop - start).seconds / 3600
-            if hours and float_compare(hours, line.unit_amount, precision_digits=4):
+            rounding = self.env.ref("uom.product_uom_hour").rounding
+            if hours and float_compare(
+                hours, line.unit_amount, precision_rounding=rounding
+            ):
                 raise exceptions.ValidationError(
                     _(
                         "The duration (%s) must be equal to the difference "

--- a/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
+++ b/hr_timesheet_activity_begin_end/tests/test_timesheet_begin_end.py
@@ -68,3 +68,8 @@ class TestBeginEnd(common.TransactionCase):
         line3.update({"time_start": 8.0, "time_stop": 15, "unit_amount": 7.0})
         with self.assertRaisesRegexp(exceptions.ValidationError, message_re):
             self.timesheet_line_model.create(line3)
+
+    def test_check_precision(self):
+        line1 = self.base_line.copy()
+        line1.update({"time_start": 19.0, "time_stop": 20.314, "unit_amount": 1.314})
+        self.timesheet_line_model.create(line1)


### PR DESCRIPTION
Current behaviour is that (stop_time - start_time) is compared to the value of unit_amount with a decimal precision of 4.

This works fine in the UI but if you try to import new records or manipulate these values programatically you run into problems. Let's take these values:

`{"time_start": 19.0, "time_stop": 20.314, "unit_amount": 1.314}
`

Python will calculate this as `1.3138888888888889` which is compared to `1.314`, this raises a validation error

`odoo.exceptions.ValidationError: ('The duration (01:19) must be equal to the difference between the hours (01:19).', None)
`

This is a confusing error for the user because 01:19 == 01:19 right? It's also not useful technically to constrain this small difference because it's just a rounding error, and the float_time widget is not sensitive to seconds anyway.

So this PR proposes the solution to compare the times as strings. It is now comparing the same values as the error message would display to the user. In this example comparing "01:19" against "01:19" returns True.