### PR TITLE
[12.0][FIX] hr_timesheet_sheet: Reviewers must be HR managers, not officers

### DIFF
--- a/hr_timesheet_sheet/README.rst
+++ b/hr_timesheet_sheet/README.rst
@@ -30,7 +30,7 @@ This module supplies a new screen enabling you to manage your work encoding
 end of the defined period, employees submit their validated sheet and the
 reviewer must then approve submitted entries. Periods are defined in the
 company forms and you can set them to run monthly, weekly or daily. By default,
-policy is configured to have HR Officer/Manager as reviewer.
+policy is configured to have HR Officers as reviewers.
 
 **Table of contents**
 
@@ -56,6 +56,9 @@ If you want other default ranges different from weekly, you need to go:
 
 To change who reviews submitted sheets, go to *Configuration > Settings > Timesheet Options*
 and configure **Timesheet Sheet Review Policy** accordingly.
+
+For adding more review policies, look at the *hr_timesheet_sheet_policy_xxx*
+extra modules.
 
 Usage
 =====

--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -347,6 +347,10 @@ class Sheet(models.Model):
         res = self.env['res.users'].browse(SUPERUSER_ID)
         if self.review_policy == 'hr':
             res |= self.env.ref('hr.group_hr_user').users
+        elif self.review_policy == 'hr_manager':
+            res |= self.env.ref('hr.group_hr_manager').users
+        elif self.review_policy == 'timesheet_manager':
+            res |= self.env.ref('hr_timesheet.group_timesheet_manager').users
         return res
 
     @api.multi

--- a/hr_timesheet_sheet/models/res_company.py
+++ b/hr_timesheet_sheet/models/res_company.py
@@ -35,7 +35,9 @@ class ResCompany(models.Model):
     timesheet_sheet_review_policy = fields.Selection(
         string='Timesheet Sheet Review Policy',
         selection=[
-            ('hr', 'By HR Manager/Officer'),
+            ('hr', 'By HR Officers'),
+            ('hr_manager', 'By HR Managers'),
+            ('timesheet_manager', 'By Timesheets Managers'),
         ],
         default='hr',
         help='How Timesheet Sheets review is performed.',

--- a/hr_timesheet_sheet/readme/CONFIGURE.rst
+++ b/hr_timesheet_sheet/readme/CONFIGURE.rst
@@ -6,3 +6,6 @@ If you want other default ranges different from weekly, you need to go:
 
 To change who reviews submitted sheets, go to *Configuration > Settings > Timesheet Options*
 and configure **Timesheet Sheet Review Policy** accordingly.
+
+For adding more review policies, look at the *hr_timesheet_sheet_policy_xxx*
+extra modules.

--- a/hr_timesheet_sheet/readme/DESCRIPTION.rst
+++ b/hr_timesheet_sheet/readme/DESCRIPTION.rst
@@ -3,4 +3,4 @@ This module supplies a new screen enabling you to manage your work encoding
 end of the defined period, employees submit their validated sheet and the
 reviewer must then approve submitted entries. Periods are defined in the
 company forms and you can set them to run monthly, weekly or daily. By default,
-policy is configured to have HR Officer/Manager as reviewer.
+policy is configured to have HR Officers as reviewers.

--- a/hr_timesheet_sheet/static/description/index.html
+++ b/hr_timesheet_sheet/static/description/index.html
@@ -373,7 +373,7 @@ ul.auto-toc {
 end of the defined period, employees submit their validated sheet and the
 reviewer must then approve submitted entries. Periods are defined in the
 company forms and you can set them to run monthly, weekly or daily. By default,
-policy is configured to have HR Officer/Manager as reviewer.</p>
+policy is configured to have HR Officers as reviewers.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -408,6 +408,8 @@ and select in <strong>Timesheet Sheet Range</strong> the default range you want.
 </ul>
 <p>To change who reviews submitted sheets, go to <em>Configuration &gt; Settings &gt; Timesheet Options</em>
 and configure <strong>Timesheet Sheet Review Policy</strong> accordingly.</p>
+<p>For adding more review policies, look at the <em>hr_timesheet_sheet_policy_xxx</em>
+extra modules.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id3">Usage</a></h1>


### PR DESCRIPTION
Current reviewer group is "Employees/Officer", which doesn't belong to the semantics of the review policy, and it's also too verbose.

@Tecnativa TT25181