### PR TITLE
[12.0][FIX] write project in sale state too to add other services

### DIFF
--- a/sale_timesheet_existing_project/__manifest__.py
+++ b/sale_timesheet_existing_project/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2020 Sergio Corato <https://github.com/sergiocorato>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
@@ -12,7 +13,9 @@
         "views/product_template_views.xml",
         "views/sale_order_views.xml",
     ],
-    "author": "Tecnativa, Odoo Community Association (OCA)",
+    "author": "Tecnativa, "
+              "Sergio Corato, "
+              "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/timesheet",
     "license": "AGPL-3",
     "installable": True,

--- a/sale_timesheet_existing_project/models/sale_order.py
+++ b/sale_timesheet_existing_project/models/sale_order.py
@@ -40,8 +40,10 @@ class SaleOrder(models.Model):
         res = super(SaleOrder, self).write(vals)
         for order in self:
             if order.state == 'sale' and order.visible_project and not \
-                    order.project_id:
-                raise UserError(_('Missing project in sale order!'))
+                    order.project_id and any(order.mapped('order_line.project_id')):
+                raise UserError(_('Missing project in sale order, but almost one '
+                                  'line of the order have a project: assign one of '
+                                  'these projects to the sale order!'))
         return res
 
 

--- a/sale_timesheet_existing_project/models/sale_order.py
+++ b/sale_timesheet_existing_project/models/sale_order.py
@@ -20,7 +20,7 @@ class SaleOrder(models.Model):
                " ('company_id', '=', company_id)]",
         readonly=True,
         states={'draft': [('readonly', False)], 'sent': [('readonly', False)],
-                'sale': [('readonly', False)]},
+                'sale': [('readonly', False)], 'done': [('readonly', False)]},
         help='Select a non billable project on which tasks can be created.')
 
     @api.depends('order_line.product_id.service_tracking')

--- a/sale_timesheet_existing_project/readme/DESCRIPTION.rst
+++ b/sale_timesheet_existing_project/readme/DESCRIPTION.rst
@@ -1,6 +1,7 @@
 This module restores the behavior present in previous version (and restored
 again in v13) of being able to reuse existing projects for generating the
 tasks when confirming a sales order with service tracking.
+
 When sale order is confirmed, product generating task can be added, but only
 the first without adding a project to the sale order, avoiding the creation
 of multiple projects.

--- a/sale_timesheet_existing_project/readme/DESCRIPTION.rst
+++ b/sale_timesheet_existing_project/readme/DESCRIPTION.rst
@@ -1,3 +1,6 @@
 This module restores the behavior present in previous version (and restored
 again in v13) of being able to reuse existing projects for generating the
 tasks when confirming a sales order with service tracking.
+When sale order is confirmed, product generating task can be added, but only
+the first without adding a project to the sale order, avoiding the creation
+of multiple projects.

--- a/sale_timesheet_existing_project/tests/test_sale_timesheet_existing_project.py
+++ b/sale_timesheet_existing_project/tests/test_sale_timesheet_existing_project.py
@@ -74,15 +74,23 @@ class TestSaleTimesheetExistingProject(common.SavepointCase):
 
     def test_sale_timesheet_new_project_set_in_sale_state(self):
         self.product.project_template_id = False
+        self.order1.write({
+            'order_line': [(
+                0, 0, {'product_id': self.product.id}
+            )]
+        })
         self.order1.action_confirm()
         self.assertEqual(self.order1.state, 'sale')
+        self.assertEqual(len(self.order1.mapped('order_line.project_id')), 1)
         with self.assertRaises(UserError):
-            self.env['sale.order.line'].create({
-                'order_id': self.order1.id,
-                'product_id': self.product.id,
+            self.order1.write({
+                'order_line': [(
+                    0, 0, {'product_id': self.product.id}
+                )]
             })
         self.order1.project_id = self.project.id
-        self.env['sale.order.line'].create({
-            'order_id': self.order1.id,
-            'product_id': self.product.id,
+        self.order1.write({
+            'order_line': [(
+                0, 0, {'product_id': self.product.id}
+            )]
         })


### PR DESCRIPTION
When a sale order is in state `sale` an user can add services with type `task_in_project` of `service_tracking` but project is readonly and he can't select one if missing. This cause creation of a new project for every line added.

With this PR user can add these services and a project on sale order. If project is not added, an UserError is raised to avoid creation of multiple projects (one for each line).