### PR TITLE
[12.0][FIX] French translation in hr_timesheet_sheet to avoid a failure on …

### DIFF
--- a/hr_timesheet_sheet/i18n/fr.po
+++ b/hr_timesheet_sheet/i18n/fr.po
@@ -1062,9 +1062,8 @@ msgstr "Semaine"
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:206
-#, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semaine"
+msgstr "Semaine %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start


### PR DESCRIPTION
…sheet computed name

Menu fails to load the data because of this mistake in the translation, we got the error : `TypeError: not all arguments converted during string formatting`

As it is a trivial patch, I appreciate if it can be merged really quick!

@sebastienbeau @pedrobaeza @astirpe @LoisRForgeFlow @bguillot 