### PR TITLE
[FIX] hr_timesheet_sheet  WARNING DB odoo.osv.expression: The domain term '('id', '=', [ID1, ID2,..., IDn])' should use the 'in' or 'not in' operator

### DIFF
--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -435,7 +435,7 @@ class TestHrTimesheetSheet(SavepointCase):
         timesheets = [x.get("id") for x in sheet_form.timesheet_ids._records]
         sheet = sheet_form.save()
         # analytic line cleaned up on form save
-        self.assertFalse(self.aal_model.search([("id", "=", timesheets)]))
+        self.assertFalse(self.aal_model.search([("id", "in", timesheets)]))
         self.assertEqual(len(sheet.line_ids), 0)
         self.assertEqual(len(sheet.timesheet_ids), 0)
         self.assertFalse(self.aal_model.search([("id", "=", timesheet.id)]))


### PR DESCRIPTION
Expected behavior: Domain should handle recordsets
Behavior: Domain give us warning of a singleton on console
WARNING openerp_test odoo.osv.expression: The domain term '('id', '=', [19])' should use the 'in' or 'not in' operator.
https://travis-ci.org/github/OCA/timesheet/jobs/690112951