### PR TITLE
[14.0][FIX] Warning triggered by the onchange

### DIFF
--- a/hr_timesheet_sheet/i18n/fr.po
+++ b/hr_timesheet_sheet/i18n/fr.po
@@ -416,6 +416,11 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet_sheet
+#: model:ir.model.fields,field_description:hr_timesheet_sheet.field_hr_timesheet_sheet__use_task_ids
+msgid "Already Used Tasks"
+msgstr "Tâche déjà utilisée(s)"
+
+#. module: hr_timesheet_sheet
 #: model:ir.model.fields,help:hr_timesheet_sheet.field_hr_timesheet_sheet__add_line_task_id
 msgid ""
 "If selected, the associated task is added to the timesheet sheet when "

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -149,6 +149,7 @@
                                     class="oe_edit_only"
                                     attrs="{'invisible': [('state', 'not in', ['new', 'draft'])]}"
                                 >
+
                                     <field
                                         name="add_line_project_id"
                                         domain="[('company_id', '=', company_id), ('allow_timesheets', '=', True)]"
@@ -157,6 +158,9 @@
                                         name="add_line_task_id"
                                         attrs="{'invisible': [('add_line_project_id', '=', False)]}"
                                         context="{'default_project_id': add_line_project_id}"
+                                        domain="use_task_ids and
+                                        [('project_id', '=', add_line_project_id), ('company_id', '=', company_id),('id', 'not in', use_task_ids)]
+                                        or [('project_id', '=', add_line_project_id), ('company_id', '=', company_id)]"
                                     />
                                     <button
                                         name="button_add_line"
@@ -169,6 +173,11 @@
                             </group>
                         </page>
                         <page string="Details">
+                            <field
+                                name="use_task_ids"
+                                widget="many2many_tags"
+                                invisible="1"
+                            />
                             <field
                                 name="timesheet_ids"
                                 nolabel="1"


### PR DESCRIPTION
Hello,
In Odoov14 a warning is display when an `@api.onchange` return the key `domain` in the dictionary.

This fix change the domain directly in the view instead of an `onchange` function