### PR TITLE
[FIX] Do not try to remove invoiced lines

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -703,7 +703,8 @@ class Sheet(models.Model):
                 lambda aal: self._is_line_of_row(aal, row)
             )
             row_lines.filtered(
-                lambda t: t.name == empty_name and not t.unit_amount
+                lambda t: t.name == empty_name and not t.unit_amount and not
+                t.timesheet_invoice_id
             ).unlink()
             if self.timesheet_ids != self.timesheet_ids.exists():
                 self._sheet_write("timesheet_ids", self.timesheet_ids.exists())


### PR DESCRIPTION
When creating a timesheet invoiced lines might be unlinked. This is (logically) blocked by Odoo base.

This PR fixes this behaviour.