### PR TITLE
[13.0] [FIX] hr_timesheet_sheet Week %s translation

### DIFF
--- a/hr_timesheet_sheet/i18n/ar.po
+++ b/hr_timesheet_sheet/i18n/ar.po
@@ -1022,7 +1022,7 @@ msgstr "الأسبوع"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "الأسبوع"
+msgstr "%s الأسبوع"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/bg.po
+++ b/hr_timesheet_sheet/i18n/bg.po
@@ -1012,7 +1012,7 @@ msgstr "Седмица"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Седмица"
+msgstr "Седмица %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/bs.po
+++ b/hr_timesheet_sheet/i18n/bs.po
@@ -1011,7 +1011,7 @@ msgstr "Sedmica"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Sedmica"
+msgstr "Sedmica %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/ca.po
+++ b/hr_timesheet_sheet/i18n/ca.po
@@ -1025,7 +1025,7 @@ msgstr "Setmana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Setmana"
+msgstr "Setmana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/cs.po
+++ b/hr_timesheet_sheet/i18n/cs.po
@@ -1014,7 +1014,7 @@ msgstr "Týden"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Týden"
+msgstr "Týden %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/da.po
+++ b/hr_timesheet_sheet/i18n/da.po
@@ -1021,7 +1021,7 @@ msgstr "Uge"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Uge"
+msgstr "Uge %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/de.po
+++ b/hr_timesheet_sheet/i18n/de.po
@@ -1019,7 +1019,7 @@ msgstr "Woche"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Wochen"
+msgstr "Wochen %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/el.po
+++ b/hr_timesheet_sheet/i18n/el.po
@@ -1011,7 +1011,7 @@ msgstr "Εβδομάδα"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Εβδομάδα"
+msgstr "Εβδομάδα %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/en_AU.po
+++ b/hr_timesheet_sheet/i18n/en_AU.po
@@ -972,7 +972,7 @@ msgstr "Week"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Week"
+msgstr ""
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/en_GB.po
+++ b/hr_timesheet_sheet/i18n/en_GB.po
@@ -1009,7 +1009,7 @@ msgstr "Week"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Week"
+msgstr ""
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/es_AR.po
+++ b/hr_timesheet_sheet/i18n/es_AR.po
@@ -1009,7 +1009,7 @@ msgstr "Semana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semana"
+msgstr "Semana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/es_CL.po
+++ b/hr_timesheet_sheet/i18n/es_CL.po
@@ -975,7 +975,7 @@ msgstr "Semana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semana"
+msgstr "Semana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/es_CR.po
+++ b/hr_timesheet_sheet/i18n/es_CR.po
@@ -1004,7 +1004,7 @@ msgstr "Semana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semana"
+msgstr "Semana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/es_EC.po
+++ b/hr_timesheet_sheet/i18n/es_EC.po
@@ -1024,7 +1024,7 @@ msgstr "Semana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semana"
+msgstr "Semana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/es_PE.po
+++ b/hr_timesheet_sheet/i18n/es_PE.po
@@ -1005,7 +1005,7 @@ msgstr "Semana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semana"
+msgstr "Semana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/es_VE.po
+++ b/hr_timesheet_sheet/i18n/es_VE.po
@@ -1002,7 +1002,7 @@ msgstr "Semana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semana"
+msgstr "Semana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/et.po
+++ b/hr_timesheet_sheet/i18n/et.po
@@ -1015,7 +1015,7 @@ msgstr "Nädal"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Nädal"
+msgstr "Nädal %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/eu.po
+++ b/hr_timesheet_sheet/i18n/eu.po
@@ -1008,7 +1008,7 @@ msgstr "Astea"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Astea"
+msgstr "Astea %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/fa.po
+++ b/hr_timesheet_sheet/i18n/fa.po
@@ -1011,7 +1011,7 @@ msgstr "هفته"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "هفته"
+msgstr "%s هفته"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/fi.po
+++ b/hr_timesheet_sheet/i18n/fi.po
@@ -1029,7 +1029,7 @@ msgstr "Viikko"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Viikko"
+msgstr "Viikko %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/gl.po
+++ b/hr_timesheet_sheet/i18n/gl.po
@@ -993,7 +993,7 @@ msgstr "Semana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semana"
+msgstr "Semana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/he.po
+++ b/hr_timesheet_sheet/i18n/he.po
@@ -981,7 +981,7 @@ msgstr "שבוע"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "שבוע"
+msgstr "%s שבוע"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/hr.po
+++ b/hr_timesheet_sheet/i18n/hr.po
@@ -1030,7 +1030,7 @@ msgstr "Tjedan"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Tjedan"
+msgstr "Tjedan %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/hu.po
+++ b/hr_timesheet_sheet/i18n/hu.po
@@ -1030,7 +1030,7 @@ msgstr "Hét"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Hét"
+msgstr "Hét %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/id.po
+++ b/hr_timesheet_sheet/i18n/id.po
@@ -1024,7 +1024,7 @@ msgstr "Pekan"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Pekan"
+msgstr "Pekan %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/ja.po
+++ b/hr_timesheet_sheet/i18n/ja.po
@@ -1027,7 +1027,7 @@ msgstr "週"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "週"
+msgstr "週 %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/ka.po
+++ b/hr_timesheet_sheet/i18n/ka.po
@@ -1003,7 +1003,7 @@ msgstr "კვირა"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "კვირა"
+msgstr "კვირა %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/kab.po
+++ b/hr_timesheet_sheet/i18n/kab.po
@@ -1009,7 +1009,7 @@ msgstr "Dduṛt"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Dduṛt"
+msgstr "Dduṛt %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/ko.po
+++ b/hr_timesheet_sheet/i18n/ko.po
@@ -1019,7 +1019,7 @@ msgstr "주"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "주"
+msgstr "주 %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/lt.po
+++ b/hr_timesheet_sheet/i18n/lt.po
@@ -1024,7 +1024,7 @@ msgstr "Savaitė"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Savaitė"
+msgstr "Savaitė %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/lv.po
+++ b/hr_timesheet_sheet/i18n/lv.po
@@ -1014,7 +1014,7 @@ msgstr "Nedēļa"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Nedēļa"
+msgstr "Nedēļa %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/mk.po
+++ b/hr_timesheet_sheet/i18n/mk.po
@@ -1017,7 +1017,7 @@ msgstr "Седмица"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Седмица"
+msgstr "Седмица %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/mn.po
+++ b/hr_timesheet_sheet/i18n/mn.po
@@ -1026,7 +1026,7 @@ msgstr "7 хоног"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "7 хоног"
+msgstr "7 хоног %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/nb.po
+++ b/hr_timesheet_sheet/i18n/nb.po
@@ -1016,7 +1016,7 @@ msgstr "Uke"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Uke"
+msgstr "Uke %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/nl_BE.po
+++ b/hr_timesheet_sheet/i18n/nl_BE.po
@@ -978,7 +978,7 @@ msgstr "Week"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Week"
+msgstr "Week %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/pl.po
+++ b/hr_timesheet_sheet/i18n/pl.po
@@ -1023,7 +1023,7 @@ msgstr "Tydzień"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Tydzień"
+msgstr "Tydzień %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/pt.po
+++ b/hr_timesheet_sheet/i18n/pt.po
@@ -1020,7 +1020,7 @@ msgstr "Semana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semana"
+msgstr "Semana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/pt_BR.po
+++ b/hr_timesheet_sheet/i18n/pt_BR.po
@@ -1015,7 +1015,7 @@ msgstr "Semana"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Semanas"
+msgstr "Semana %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/ro.po
+++ b/hr_timesheet_sheet/i18n/ro.po
@@ -1015,7 +1015,7 @@ msgstr "Săptămână"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Săptămână"
+msgstr "Săptămână %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/ru.po
+++ b/hr_timesheet_sheet/i18n/ru.po
@@ -1032,7 +1032,7 @@ msgstr "Неделя"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Неделя"
+msgstr "Неделя %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/sk.po
+++ b/hr_timesheet_sheet/i18n/sk.po
@@ -1024,7 +1024,7 @@ msgstr "Týždeň"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Týždeň"
+msgstr "Týždeň %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/sl.po
+++ b/hr_timesheet_sheet/i18n/sl.po
@@ -1017,7 +1017,7 @@ msgstr "Teden"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Teden"
+msgstr "Teden %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/sr@latin.po
+++ b/hr_timesheet_sheet/i18n/sr@latin.po
@@ -1003,7 +1003,7 @@ msgstr "Nedelja"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Nedelja"
+msgstr "Nedelja %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/sv.po
+++ b/hr_timesheet_sheet/i18n/sv.po
@@ -1025,7 +1025,7 @@ msgstr "Vecka"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Vecka"
+msgstr "Vecka %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/th.po
+++ b/hr_timesheet_sheet/i18n/th.po
@@ -1013,7 +1013,7 @@ msgstr "สัปดาห์"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "สัปดาห์"
+msgstr "สัปดาห์ %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/tr.po
+++ b/hr_timesheet_sheet/i18n/tr.po
@@ -1035,7 +1035,7 @@ msgstr "Hafta"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Hafta"
+msgstr "Hafta %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/uk.po
+++ b/hr_timesheet_sheet/i18n/uk.po
@@ -1026,7 +1026,7 @@ msgstr "Тиждень"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Тиждень"
+msgstr "Тиждень %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/vi.po
+++ b/hr_timesheet_sheet/i18n/vi.po
@@ -1012,7 +1012,7 @@ msgstr "Tuần"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "Tuần"
+msgstr "Tuần %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/zh_CN.po
+++ b/hr_timesheet_sheet/i18n/zh_CN.po
@@ -1015,7 +1015,7 @@ msgstr "周"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "周"
+msgstr "周 %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start

--- a/hr_timesheet_sheet/i18n/zh_TW.po
+++ b/hr_timesheet_sheet/i18n/zh_TW.po
@@ -1018,7 +1018,7 @@ msgstr "周"
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0
 #, fuzzy, python-format
 msgid "Week %s"
-msgstr "周"
+msgstr "周 %s"
 
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields,field_description:hr_timesheet_sheet.field_res_config_settings__timesheet_week_start


### PR DESCRIPTION
The issue reported on OCA/timesheet/#370 is also affecting 13.0 as shown in OCA/timesheet/#426

Taking OCA/timesheet/#371 as a reference, this commit fixes the translations of 'Week %s' on various locale translation files that don't include '%s'.

It is essentially the same work done on OCA/timesheet/#453 for the 14.0 branch but for the 13.0 branch.