### PR TITLE
 [IMP] hr_timesheet_activity_begin_end: add time_start and time_stop also on project.task form view

### DIFF
--- a/hr_timesheet_activity_begin_end/__manifest__.py
+++ b/hr_timesheet_activity_begin_end/__manifest__.py
@@ -10,7 +10,11 @@
     "category": "Human Resources",
     "depends": ["hr_timesheet_sheet"],
     "website": "https://github.com/OCA/timesheet",
-    "data": ["views/hr_analytic_timesheet.xml", "views/hr_timesheet_sheet.xml"],
+    "data": [
+        "views/hr_analytic_timesheet.xml",
+        "views/hr_timesheet_sheet.xml",
+        "views/project_task.xml",
+    ],
     "installable": True,
     "auto_install": False,
 }

--- a/hr_timesheet_activity_begin_end/views/project_task.xml
+++ b/hr_timesheet_activity_begin_end/views/project_task.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_project_task_form" model="ir.ui.view">
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='timesheet_ids']/tree/field[@name='unit_amount']"
+                position="before"
+            >
+                <field name="time_start" widget="float_time" />
+                <field name="time_stop" widget="float_time" />
+            </xpath>
+            <xpath
+                expr="//field[@name='timesheet_ids']/form/sheet/group/field[@name='unit_amount']"
+                position="before"
+            >
+                <field name="time_start" widget="float_time" />
+                <field name="time_stop" widget="float_time" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Hi, 

Just begin to use this great module (``hr_timesheet_activity_begin_end``). thanks !

- the two new field are missing in the ``project.task`` form view, that contains a tree view of timesheet.
- this trivial PR improves the ``project.task`` view adding the two fields.

CC : authors / maintainers : @ guewen, @schhatbar-initos, @bodi000, @davejames, @astirpe.

