### PR TITLE
[14.0][FIX]  hr_timesheet_sheet - Do not merge invoiced timesheet lines

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -666,7 +666,7 @@ class Sheet(models.Model):
                 aal.write({"sheet_id": self.id})
 
     def clean_timesheets(self, timesheets):
-        repeated = timesheets.filtered(lambda t: t.name == empty_name)
+        repeated = timesheets.filtered(lambda t: t.name == empty_name and not t.timesheet_invoice_id)
         if len(repeated) > 1 and self.id:
             return repeated.merge_timesheets()
         return timesheets


### PR DESCRIPTION
Merging invoiced analytic lines results in:
raise UserError(_('You cannot remove a timesheet that has already been invoiced.'))

@pedrobaeza should be a straightforward fix