### PR TITLE
{13.0}[PORT] 363 from 12.0 [FIX] project_timesheet_time_control: incompatible with sale_timesheet_rounded

### DIFF
--- a/sale_timesheet_rounded/models/account_analytic_line.py
+++ b/sale_timesheet_rounded/models/account_analytic_line.py
@@ -94,7 +94,7 @@ class AccountAnalyticLine(models.Model):
         This affects `account_analytic_line._sale_determine_order_line`.
         """
         ctx_ts_rounded = self.env.context.get("timesheet_rounding")
-        fields_local = fields.copy() if fields else []
+        fields_local = list(fields) if fields else []
         read_unit_amount = "unit_amount" in fields_local or not fields_local
         if ctx_ts_rounded and read_unit_amount and fields_local:
             if "unit_amount_rounded" not in fields_local:


### PR DESCRIPTION
{#363} from 12.0 to 13.0
(generated automatically with the port-pr module)