### PR TITLE
[14.0][FIX] hr_timesheet_sheet: Add sale_timesheet dependency

### DIFF
--- a/hr_timesheet_sheet/__manifest__.py
+++ b/hr_timesheet_sheet/__manifest__.py
@@ -15,7 +15,7 @@
     "website": "https://github.com/OCA/timesheet",
     "installable": True,
     "auto_install": False,
-    "depends": ["hr_timesheet", "web_widget_x2many_2d_matrix"],
+    "depends": ["hr_timesheet", "sale_timesheet", "web_widget_x2many_2d_matrix"],
     "data": [
         "data/hr_timesheet_sheet_data.xml",
         "security/ir.model.access.csv",


### PR DESCRIPTION
Add `sale_timesheet` dependency (`timesheet_invoice_id` field of `account.analytic.line` adds it).

Tests currently fail without having `sale_timesheet` addon installed.

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT35948