### PR TITLE
[14.0] hr_timesheet_sheet: Error when using English language

### DIFF
--- a/hr_timesheet_sheet/i18n/en_AU.po
+++ b/hr_timesheet_sheet/i18n/en_AU.po
@@ -995,7 +995,7 @@ msgstr ""
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields.selection,name:hr_timesheet_sheet.selection__res_company__sheet_range__weekly
 msgid "Week"
-msgstr "Week"
+msgstr ""
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0

--- a/hr_timesheet_sheet/i18n/en_GB.po
+++ b/hr_timesheet_sheet/i18n/en_GB.po
@@ -1031,7 +1031,7 @@ msgstr ""
 #. module: hr_timesheet_sheet
 #: model:ir.model.fields.selection,name:hr_timesheet_sheet.selection__res_company__sheet_range__weekly
 msgid "Week"
-msgstr "Week"
+msgstr ""
 
 #. module: hr_timesheet_sheet
 #: code:addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py:0


### PR DESCRIPTION
On the main Discussion tab it throws an error saying not all items are included on "Week %s" because there is a "Week" that is also translated.
This removes the unuseful translation and fixes that translation error.