### PR TITLE
[14.0][FIX] hr_timesheet_task_stage: Avoid texts on buttons

### DIFF
--- a/hr_timesheet_task_stage/views/account_analytic_line.xml
+++ b/hr_timesheet_task_stage/views/account_analytic_line.xml
@@ -13,7 +13,7 @@
                 <field name="is_task_closed" invisible="1" />
                 <button
                     name="action_close_task"
-                    string="Close task"
+                    title="Close task"
                     tabindex="-1"
                     type="object"
                     icon="fa-folder-o"
@@ -21,7 +21,7 @@
                 />
                 <button
                     name="action_open_task"
-                    string="Open task"
+                    title="Open task"
                     tabindex="-1"
                     type="object"
                     icon="fa-folder-open-o"


### PR DESCRIPTION
Since v14, string attribute of elements are directly shown in the views as text instead of being a tooltip, and thus, it takes a lot of space in screen.

And it was not the intended visualization when the module was conceived, just a side effect.

Thus, we restore what we expect, moving string to title for having the tooltips again.

**Before**

![LAljVG_PfG](https://user-images.githubusercontent.com/7165771/197860977-97758204-1369-49f3-9d85-66036cd8bd04.png)

**After**

![Selección_005](https://user-images.githubusercontent.com/7165771/197861175-ab04e208-c2d5-4ee5-961c-55da24deb425.png)

@Tecnativa TT40169