### PR TITLE
[13.0] Updated repo from template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,15 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.7.0
+_commit: v1.11.1
 _src_path: https://github.com/OCA/oca-addons-repo-template.git
 ci: GitHub
 dependency_installation_mode: OCA
 generate_requirements_txt: true
-include_wkhtmltopdf: false
+github_check_license: true
+github_enable_codecov: true
+github_enable_makepot: true
+github_enable_stale_action: true
+github_enforce_dev_status_compatibility: true
+include_wkhtmltopdf: true
 odoo_version: 13.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ build/
 develop-eggs/
 dist/
 eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,11 +102,17 @@ repos:
         name: isort except __init__.py
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.3
+    rev: 3.1.8
     hooks:
       - id: setuptools-odoo-make-default
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+      - id: setuptools-odoo-get-requirements
+        args:
+          - --output
+          - requirements.txt
+          - --header
+          - "# generated from manifests external_dependencies"
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.7.9
     hooks:
       - id: flake8
         name: flake8


### PR DESCRIPTION
Did a copier update according to https://github.com/OCA/oca-addons-repo-template

This should fix broken github actions in #474 and #456

@OCA/timesheet-maintainers
@nimarosa Can you merge/fasttrack this?