### PR TITLE
[14.0][IMP] hr_timesheet_time_restriction: Timesheet restriction Add same day option

### DIFF
--- a/hr_timesheet_time_restriction/models/account_analytic_line.py
+++ b/hr_timesheet_time_restriction/models/account_analytic_line.py
@@ -33,15 +33,38 @@ class AccountAnalyticLine(models.Model):
             )
         )
         today = date.today()
+        use_timesheet_restriction = (
+            True
+            if self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("hr_timesheet_time_restriction.use_timesheet_restriction", False)
+            else False
+        )
+
         for record in self.filtered(lambda rec: rec.date and rec.project_id):
-            days = (
-                record.project_id.timesheet_restriction_days
-                or timesheet_restriction_days
-            )
-            if days and today - relativedelta(days=days) > record.date:
-                raise ValidationError(
-                    _(
-                        "You cannot change or create a timesheet "
-                        'with a specified "date" in the past.'
-                    ),
+            if use_timesheet_restriction or record.project_id.use_timesheet_restriction:
+                days = (
+                    record.project_id.timesheet_restriction_days
+                    or timesheet_restriction_days
                 )
+                if days and today - relativedelta(days=days) > record.date:
+                    raise ValidationError(
+                        _(
+                            "You cannot set a timesheet more than"
+                            " {days} days from current date.".format(
+                                days=record.project_id.timesheet_restriction_days
+                            ),
+                        )
+                    )
+                if (
+                    record.project_id.timesheet_restriction_days
+                    == timesheet_restriction_days
+                    == 0
+                    and today != record.date
+                ):
+                    raise ValidationError(
+                        _(
+                            "You cannot set a timesheet for a "
+                            "date different from current date"
+                        )
+                    )

--- a/hr_timesheet_time_restriction/models/project_project.py
+++ b/hr_timesheet_time_restriction/models/project_project.py
@@ -15,12 +15,28 @@ class ProjectProject(models.Model):
         """
         Check that the `timesheet_restriction_days` is positive
         """
+        use_timesheet_restriction = (
+            True
+            if self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("hr_timesheet_time_restriction.use_timesheet_restriction", False)
+            else False
+        )
         for record in self:
-            if record.timesheet_restriction_days < 0:
-                raise ValidationError(
-                    _("The day of the timesheet restriction must not be negative.")
-                )
+            if use_timesheet_restriction:
+                if record.timesheet_restriction_days < 0:
+                    raise ValidationError(
+                        _("The day of the timesheet restriction must not be negative.")
+                    )
 
     timesheet_restriction_days = fields.Integer(
         default=0, help="Not active if equal to 0."
+    )
+
+    use_timesheet_restriction = fields.Boolean(
+        default=lambda self: True
+        if self.env["ir.config_parameter"]
+        .sudo()
+        .get_param("hr_timesheet_time_restriction.use_timesheet_restriction", False)
+        else False
     )

--- a/hr_timesheet_time_restriction/models/res_config_settings.py
+++ b/hr_timesheet_time_restriction/models/res_config_settings.py
@@ -29,3 +29,7 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="hr_timesheet_time_restriction.timesheet_restriction_days",
         default=0,
     )
+
+    use_timesheet_restriction = fields.Boolean(
+        config_parameter="hr_timesheet_time_restriction.use_timesheet_restriction"
+    )

--- a/hr_timesheet_time_restriction/readme/CONFIGURE.rst
+++ b/hr_timesheet_time_restriction/readme/CONFIGURE.rst
@@ -1,3 +1,8 @@
-Specific Project Timesheet Restriction: Project > Configuration > Projects > Open Project > set "Timesheet Restriction (days)"
-Global Timesheet Restriction: Timesheets > Configuration > Settings > set "Timesheet Restriction (days)"
-Ignore User Timesheet Restriction: Settings > Users & Companies > Users > Open User > Technical > set "No Timesheet Date Restriction"
+Specific project timesheet restriction:
+ - Project > Configuration > Projects > open project > enable "Use timesheet restriction" and set "Timesheet Restriction (days)"
+
+Global timesheet restriction:
+ - Timesheets > Configuration > Settings > enable "Use timesheet restriction" and set "Timesheet Restriction (days)" (note: it will only apply to newly created projects)
+
+Ignore user timesheet restriction:
+ - Settings > Users & Companies > Users > open user > Technical: set "No Timesheet Date Restriction"

--- a/hr_timesheet_time_restriction/tests/__init__.py
+++ b/hr_timesheet_time_restriction/tests/__init__.py
@@ -1,1 +1,2 @@
-from . import test_hr_timesheet_time_restriction
+from . import test_enabled_hr_timesheet_time_restriction
+from . import test_disabled_hr_timesheet_time_restriction

--- a/hr_timesheet_time_restriction/tests/test_disabled_hr_timesheet_time_restriction.py
+++ b/hr_timesheet_time_restriction/tests/test_disabled_hr_timesheet_time_restriction.py
@@ -1,0 +1,142 @@
+# Copyright 2022 Dinar Gabbasov
+# Copyright 2022 Ooops404
+# Copyright 2022 Cetmix
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import datetime
+
+from odoo.exceptions import ValidationError
+from odoo.tests import common
+
+
+class TestHrTimesheetTimeRestriction(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+        self.project = self.env["project.project"].create({"name": "Test project"})
+        self.analytic_account = self.project.analytic_account_id
+        self.task = self.env["project.task"].create(
+            {
+                "name": "Test task",
+                "project_id": self.project.id,
+            }
+        )
+        self.config = self.env["res.config.settings"].create({})
+        self.config.use_timesheet_restriction = False
+        self.config.execute()
+
+    def test_project_restriction_days(self):
+        self.project.timesheet_restriction_days = 1
+        # check that we can create new timesheet
+        line = self.env["account.analytic.line"].create(
+            {
+                "date": datetime.date.today(),
+                "task_id": self.task.id,
+                "project_id": self.project.id,
+                "account_id": self.analytic_account.id,
+                "name": "Test line",
+            }
+        )
+        self.assertTrue(line, "Timesheet should be created")
+        # check that we can create new timesheet with date before
+        # that current date - 1
+        line = False
+        line = self.env["account.analytic.line"].create(
+            {
+                "date": datetime.date.today() - datetime.timedelta(days=2),
+                "task_id": self.task.id,
+                "project_id": self.project.id,
+                "account_id": self.analytic_account.id,
+                "name": "Test line",
+            }
+        )
+        self.assertTrue(line, "Timesheet should be created")
+
+    def test_project_restriction_days_by_config(self):
+        config = self.env["res.config.settings"].create({})
+        config.timesheet_restriction_days = 1
+        config.execute()
+        # check that we can create new timesheet
+        line = self.env["account.analytic.line"].create(
+            {
+                "date": datetime.date.today() - datetime.timedelta(days=1),
+                "task_id": self.task.id,
+                "project_id": self.project.id,
+                "account_id": self.analytic_account.id,
+                "name": "Test line",
+            }
+        )
+        self.assertTrue(line, "Timesheet should be created")
+        # check that we cannot create new timesheet with date before
+        # that current date - 1
+        line = False
+        line = self.env["account.analytic.line"].create(
+            {
+                "date": datetime.date.today() - datetime.timedelta(days=2),
+                "task_id": self.task.id,
+                "project_id": self.project.id,
+                "account_id": self.analytic_account.id,
+                "name": "Test line",
+            }
+        )
+        self.assertTrue(line, "Timesheet should be created")
+
+    def test_project_restriction_days_ignore_config(self):
+        config = self.env["res.config.settings"].create({})
+        config.timesheet_restriction_days = 1
+        config.execute()
+        self.project.timesheet_restriction_days = 2
+        line = self.env["account.analytic.line"].create(
+            {
+                "date": datetime.date.today() - datetime.timedelta(days=2),
+                "task_id": self.task.id,
+                "project_id": self.project.id,
+                "account_id": self.analytic_account.id,
+                "name": "Test line",
+            }
+        )
+        self.assertTrue(line, "Timesheet should be created")
+        # check that we cannot create new timesheet with date before
+        # that current date - 2
+        line = False
+        line = self.env["account.analytic.line"].create(
+            {
+                "date": datetime.date.today() - datetime.timedelta(days=3),
+                "task_id": self.task.id,
+                "project_id": self.project.id,
+                "account_id": self.analytic_account.id,
+                "name": "Test line",
+            }
+        )
+        self.assertTrue(line, "Timesheet should be created")
+
+    def test_project_restriction_days_ignore_for_timesheet_time_manager(self):
+        group = self.ref("hr_timesheet_time_restriction.group_timesheet_time_manager")
+        self.env.user.groups_id = [(4, group)]
+        self.project.timesheet_restriction_days = 1
+        # check that we can create new timesheet with date before
+        # that current date - 1
+        line = self.env["account.analytic.line"].create(
+            {
+                "date": datetime.date.today() - datetime.timedelta(days=2),
+                "task_id": self.task.id,
+                "project_id": self.project.id,
+                "account_id": self.analytic_account.id,
+                "name": "Test line",
+            }
+        )
+        self.assertTrue(line, "Timesheet should be created")
+
+    def test_set_negative_project_restriction_days(self):
+        try:
+            self.project.timesheet_restriction_days = -1
+        except ValidationError:
+            self.project.timesheet_restriction_days = 0
+        self.assertNotEqual(self.project.timesheet_restriction_days, 0)
+
+    def test_set_negative_config_restriction_days(self):
+        config = self.env["res.config.settings"].create({})
+        config.timesheet_restriction_days = -1
+        config._onchange_timesheet_restriction_days()
+        config.execute()
+        self.assertEqual(config.timesheet_restriction_days, 0)

--- a/hr_timesheet_time_restriction/views/project_project_view.xml
+++ b/hr_timesheet_time_restriction/views/project_project_view.xml
@@ -9,6 +9,17 @@
             <xpath expr="//div[@name='options_active']" position="inside">
                 <div>
                     <label
+                        for="use_timesheet_restriction"
+                        string="Use timesheet restriction"
+                        class="oe_inline"
+                    />
+                    <field
+                        name="use_timesheet_restriction"
+                        class="oe_inline oe_input_align"
+                    />
+                </div>
+                <div attrs="{'invisible': [('use_timesheet_restriction', '=', False)]}">
+                    <label
                         for="timesheet_restriction_days"
                         class="oe_inline"
                         string="Timesheet Restriction (days):"
@@ -21,5 +32,4 @@
             </xpath>
         </field>
     </record>
-
 </odoo>

--- a/hr_timesheet_time_restriction/views/res_config_settings_view.xml
+++ b/hr_timesheet_time_restriction/views/res_config_settings_view.xml
@@ -11,7 +11,24 @@
                 position="inside"
             >
                 <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="use_timesheet_restriction" />
+                    </div>
                     <div class="o_setting_right_pane">
+                        <label
+                            for="use_timesheet_restriction"
+                            string="Auto-enable Timesheet restriction"
+                        />
+                        <div class="content-group">
+                            <div class="mt16">
+                            </div>
+                        </div>
+                    </div>
+
+                    <div
+                        class="o_setting_right_pane"
+                        attrs="{'invisible': [('use_timesheet_restriction', '=', False)]}"
+                    >
                         <label
                             for="timesheet_restriction_days"
                             string="Timesheet Restriction (days)"


### PR DESCRIPTION
- added a flag "Use timesheet restriction" in project
- added a flag global settings "Auto-enable Timesheet restriction"
- updated the logic of the method behavior _check_project_date