### PR TITLE
[14.0][IMP] hr_timesheet_activity_begin_end: missing form fields

### DIFF
--- a/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
+++ b/hr_timesheet_activity_begin_end/views/hr_analytic_timesheet.xml
@@ -11,4 +11,17 @@
             </field>
         </field>
     </record>
+    <record id="hr_timesheet_line_form" model="ir.ui.view">
+        <field
+            name="name"
+        >account.analytic.line.form (in hr_timesheet_activity_begin_end)</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form" />
+        <field name="arch" type="xml">
+            <field name="unit_amount" position="before">
+                <field name="time_start" widget="float_time" />
+                <field name="time_stop" widget="float_time" />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
`time_start` and `time_stop` fields were missing in timesheets `form` view. This PR adds them.