### PR TITLE
[14.0][IMP] hr_timesheet_activity_begin_end: missing fields in task views

### DIFF
--- a/hr_timesheet_activity_begin_end/__manifest__.py
+++ b/hr_timesheet_activity_begin_end/__manifest__.py
@@ -10,7 +10,11 @@
     "category": "Human Resources",
     "depends": ["hr_timesheet_sheet"],
     "website": "https://github.com/OCA/timesheet",
-    "data": ["views/hr_analytic_timesheet.xml", "views/hr_timesheet_sheet.xml"],
+    "data": [
+        "views/hr_analytic_timesheet.xml",
+        "views/hr_timesheet_sheet.xml",
+        "views/project_task.xml",
+    ],
     "installable": True,
     "auto_install": False,
 }

--- a/hr_timesheet_activity_begin_end/views/project_task.xml
+++ b/hr_timesheet_activity_begin_end/views/project_task.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_task_form2_inherited" model="ir.ui.view">
+        <field
+            name="name"
+        >project.task.form.inherited (in hr_timesheet_activity_begin_end)</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='timesheet_ids']/tree/field[@name='unit_amount']"
+                position="before"
+            >
+                <field name="time_start" widget="float_time" />
+                <field name="time_stop" widget="float_time" />
+            </xpath>
+            <xpath
+                expr="//field[@name='timesheet_ids']/form/sheet/group/field[@name='unit_amount']"
+                position="before"
+            >
+                <field name="time_start" widget="float_time" />
+                <field name="time_stop" widget="float_time" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
New `time_start` and `time_stop` fields are not shown in task form, this PR adds them.