### PR TITLE
FIX: compute called on project_id field when there is no change

### DIFF
--- a/sale_timesheet_rounded/__init__.py
+++ b/sale_timesheet_rounded/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from .hooks import pre_init_hook
+from . import wizard

--- a/sale_timesheet_rounded/models/__init__.py
+++ b/sale_timesheet_rounded/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_analytic_line
 from . import project_project
 from . import sale
+from . import account_move

--- a/sale_timesheet_rounded/models/account_analytic_line.py
+++ b/sale_timesheet_rounded/models/account_analytic_line.py
@@ -18,6 +18,14 @@ class AccountAnalyticLine(models.Model):
         copy=False,
     )
 
+    @api.depends("timesheet_invoice_id.state")
+    def _compute_project_id(self):
+        res = super()._compute_project_id()
+        field_rounded = self._fields["unit_amount_rounded"]
+        if self._context.get("timesheet_no_recompute", False):
+            self.env.remove_to_compute(field_rounded, self)
+        return res
+
     @api.depends("project_id", "unit_amount")
     def _compute_unit_rounded(self):
         for record in self:

--- a/sale_timesheet_rounded/models/account_move.py
+++ b/sale_timesheet_rounded/models/account_move.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+
+    _inherit = "account.move"
+
+    def unlink(self):
+        return super(
+            AccountMove, self.with_context(timesheet_no_recompute=True)
+        ).unlink()

--- a/sale_timesheet_rounded/wizard/__init__.py
+++ b/sale_timesheet_rounded/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_make_invoice_advance

--- a/sale_timesheet_rounded/wizard/sale_make_invoice_advance.py
+++ b/sale_timesheet_rounded/wizard/sale_make_invoice_advance.py
@@ -1,0 +1,21 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class SaleAdvancePaymentInv(models.TransientModel):
+
+    _inherit = "sale.advance.payment.inv"
+
+    def create_invoices(self):
+        """Override method from sale/wizard/sale_make_invoice_advance.py
+
+        When the user want to invoice the timesheets to the SO
+        up to a specific period then we need to recompute the
+        qty_to_invoice for each product_id in sale.order.line,
+        before creating the invoice.
+        """
+        return super(
+            SaleAdvancePaymentInv, self.with_context(timesheet_no_recompute=True)
+        ).create_invoices()


### PR DESCRIPTION
This is causing the field to be set as computed, but there is no real change

We don't want to compute the field in this case

To propagate the name & project_id on the aal, odoo has added https://github.com/odoo/odoo/pull/106164/files#diff-edc6b8dbe8bb37262518fb2d4e6dafd03a4aff0715a592ee1472c8d198e840ebR73

This is causing the field aal.project_id to be considered as computed, but it is not.
It will then call the `@api.depends('project_id',...)` on the computation of the `unit_amount_rounded` (even if there was no change on the value of `aal.project_id`.

When we create a new invoice or delete it, we don't want to change the value of `unit_amount_rounded`
