### PR TITLE
[15.0][FIX] sale_timesheet_rounded: avoid recomputing rounded amounts when not needed

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -14,7 +14,8 @@ odoo_test_flavor: Both
 odoo_version: 15.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- sale_timesheet_rounded
 repo_description: 'TODO: add repo description.'
 repo_name: timesheet
 repo_slug: timesheet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,18 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.8-odoo15.0:latest
+            include: "sale_timesheet_rounded"
+            makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.8-ocb15.0:latest
+            include: "sale_timesheet_rounded"
+            name: test with OCB
+          - container: ghcr.io/oca/oca-ci/py3.8-odoo15.0:latest
+            exclude: "sale_timesheet_rounded"
+            makepot: "true"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.8-ocb15.0:latest
+            exclude: "sale_timesheet_rounded"
             name: test with OCB
             makepot: "true"
     services:
@@ -49,6 +59,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
           - container: ghcr.io/oca/oca-ci/py3.8-ocb15.0:latest
             exclude: "sale_timesheet_rounded"
             name: test with OCB
-            makepot: "true"
     services:
       postgres:
         image: postgres:9.6

--- a/sale_timesheet_rounded/__init__.py
+++ b/sale_timesheet_rounded/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from .hooks import pre_init_hook
+from . import wizard

--- a/sale_timesheet_rounded/hooks.py
+++ b/sale_timesheet_rounded/hooks.py
@@ -24,5 +24,5 @@ def pre_init_hook(cr):
     cr.execute(  # pylint: disable=E8103
         sql.SQL(
             "UPDATE {table} SET {column} = unit_amount WHERE {column} IS NULL"
-        ).format(table=table, column=column),
+        ).format(table=table, column=column)
     )

--- a/sale_timesheet_rounded/models/__init__.py
+++ b/sale_timesheet_rounded/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_analytic_line
 from . import project_project
 from . import sale
+from . import account_move

--- a/sale_timesheet_rounded/models/account_analytic_line.py
+++ b/sale_timesheet_rounded/models/account_analytic_line.py
@@ -18,6 +18,13 @@ class AccountAnalyticLine(models.Model):
         copy=False,
     )
 
+    @api.depends("timesheet_invoice_id.state")
+    def _compute_project_id(self):
+        field_rounded = self._fields["unit_amount_rounded"]
+        if self._context.get("timesheet_no_recompute", False):
+            self.env.remove_to_compute(field_rounded, self)
+        return super()._compute_project_id()
+
     @api.depends("project_id", "unit_amount")
     def _compute_unit_rounded(self):
         for record in self:

--- a/sale_timesheet_rounded/models/account_move.py
+++ b/sale_timesheet_rounded/models/account_move.py
@@ -1,0 +1,31 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+
+    _inherit = "account.move"
+
+    def _post(self, soft=True):
+        # We must avoid the recomputation of the unit amount rounded called by
+        # the compute_project_id (especially when project has not been changed)
+        return super(AccountMove, self.with_context(timesheet_no_recompute=True))._post(
+            soft=soft
+        )
+
+    def unlink(self):
+        return super(
+            AccountMove, self.with_context(timesheet_no_recompute=True)
+        ).unlink()
+
+    def button_cancel(self):
+        return super(
+            AccountMove, self.with_context(timesheet_no_recompute=True)
+        ).button_cancel()
+
+    def button_draft(self):
+        return super(
+            AccountMove, self.with_context(timesheet_no_recompute=True)
+        ).button_draft()

--- a/sale_timesheet_rounded/wizard/__init__.py
+++ b/sale_timesheet_rounded/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_make_invoice_advance

--- a/sale_timesheet_rounded/wizard/sale_make_invoice_advance.py
+++ b/sale_timesheet_rounded/wizard/sale_make_invoice_advance.py
@@ -1,0 +1,21 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class SaleAdvancePaymentInv(models.TransientModel):
+
+    _inherit = "sale.advance.payment.inv"
+
+    def create_invoices(self):
+        """Override method from sale/wizard/sale_make_invoice_advance.py
+
+        When the user want to invoice the timesheets to the SO
+        up to a specific period then we need to recompute the
+        qty_to_invoice for each product_id in sale.order.line,
+        before creating the invoice.
+        """
+        return super(
+            SaleAdvancePaymentInv, self.with_context(timesheet_no_recompute=True)
+        ).create_invoices()


### PR DESCRIPTION
Superseed https://github.com/OCA/timesheet/pull/585

This is causing the field to be set as computed, but there is no real change

We don't want to compute the field in these cases:

 - To propagate the name & project_id on the aal, odoo has added https://github.com/odoo/odoo/pull/106164/files#diff-edc6b8dbe8bb37262518fb2d4e6dafd03a4aff0715a592ee1472c8d198e840ebR73
 - When we draft, cancel, delete or post an invoice
 - When we impute an advanced payment to a sale order


This is causing the field aal.project_id to be considered as computed, but it is not.
It will then call the @api.depends('project_id',...) on the computation of the unit_amount_rounded (even if there was no change on the value of aal.project_id.