### PR TITLE
[15.0][FIX] hr_timesheet_sheet: `image_128` -> `avatar_128` (forward port)

### DIFF
--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -249,7 +249,7 @@
                             <div class="row no-gutters">
                                 <div class="col-2">
                                     <img
-                                        t-att-src="kanban_image('hr.employee', 'image_small', record.employee_id.raw_value)"
+                                        t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)"
                                         t-att-title="record.employee_id.value"
                                         t-att-alt="record.employee_id.value"
                                         width="40"


### PR DESCRIPTION
Forward port of https://github.com/OCA/timesheet/pull/611.