### PR TITLE
[14.0][IMP] hr_timesheet_sheet: Improve search speed for can_review field

### DIFF
--- a/hr_timesheet_sheet_policy_department_manager/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_policy_department_manager/models/hr_timesheet_sheet.py
@@ -52,6 +52,21 @@ class HrTimesheetSheet(models.Model):
             result += [self.department_id.name_get()[0][1]]
         return result
 
+    @api.model
+    def _get_user_possible_review_policies(self):
+        review_policy_domains = super()._get_user_possible_review_policies()
+        department_manager_domain = [
+            "&",
+            ("review_policy", "=", "department_manager"),
+            ("department_id.manager_id.user_id", "=", self.env.uid),
+        ]
+        review_policy_domains = (
+            department_manager_domain
+            if not review_policy_domains
+            else ["|"] + department_manager_domain + review_policy_domains
+        )
+        return review_policy_domains
+
     def _get_possible_reviewers(self):
         self.ensure_one()
         res = super()._get_possible_reviewers()

--- a/hr_timesheet_sheet_policy_project_manager/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_policy_project_manager/models/hr_timesheet_sheet.py
@@ -62,6 +62,21 @@ class HrTimesheetSheet(models.Model):
                     )
                 )
 
+    @api.model
+    def _get_user_possible_review_policies(self):
+        review_policy_domains = super()._get_user_possible_review_policies()
+        project_manager_domain = [
+            "&",
+            ("review_policy", "=", "project_manager"),
+            ("project_id.user_id", "=", self.env.uid),
+        ]
+        review_policy_domains = (
+            project_manager_domain
+            if not review_policy_domains
+            else ["|"] + project_manager_domain + review_policy_domains
+        )
+        return review_policy_domains
+
     def _get_possible_reviewers(self):
         self.ensure_one()
         res = super()._get_possible_reviewers()


### PR DESCRIPTION
This is a followup to #581 taking into account the feedback by @len-foss 
Remedies slowdowns in search speed when there are lots of timesheets by avoiding expensive call to 
```python
self.search([]).filtered(
            lambda sheet: check(sheet._get_possible_reviewers())
        )
```
and not passing a domain that checks for exclusion/inclusion against lots of timesheet ids.