### PR TITLE
[15.0][IMP] hr_timesheet_sheet: add My Current Timesheet menu.

### DIFF
--- a/hr_timesheet_sheet/__init__.py
+++ b/hr_timesheet_sheet/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizard

--- a/hr_timesheet_sheet/security/ir.model.access.csv
+++ b/hr_timesheet_sheet/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hr_timesheet_sheet_user,hr_timesheet.sheet,model_hr_timesheet_sheet,base.group_user,1,1,1,1
 access_hr_timesheet_sheet_line,hr_timesheet.sheet.line,model_hr_timesheet_sheet_line,hr_timesheet.group_hr_timesheet_user,1,1,1,1
 access_hr_timesheet_sheet_new_analytic_line,hr_timesheet.sheet.new.analyticline,model_hr_timesheet_sheet_new_analytic_line,hr_timesheet.group_hr_timesheet_user,1,1,1,1
+access_hr_timesheet_user_open_current,hr_timesheet.current.open,model_hr_timesheet_current_open,base.group_user,1,1,1,1

--- a/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
+++ b/hr_timesheet_sheet/views/hr_timesheet_sheet_views.xml
@@ -512,4 +512,20 @@
         parent="menu_hr_to_review"
         sequence="11"
     />
+    <record id="ir_actions_server_timesheet_sheet" model="ir.actions.server">
+        <field name="sequence" eval="5" />
+        <field name="state">code</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="model_hr_timesheet_current_open" />
+        <field name="code">action = model.open_timesheet()</field>
+        <field name="name">My Timesheet</field>
+    </record>
+
+    <menuitem
+        name="My Current Timesheet"
+        id="menu_act_hr_timesheet_sheet_form_my_current"
+        parent="hr_timesheet.menu_hr_time_tracking"
+        action="ir_actions_server_timesheet_sheet"
+        sequence="2"
+    />
 </odoo>

--- a/hr_timesheet_sheet/wizard/__init__.py
+++ b/hr_timesheet_sheet/wizard/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import hr_timesheet_current

--- a/hr_timesheet_sheet/wizard/hr_timesheet_current.py
+++ b/hr_timesheet_sheet/wizard/hr_timesheet_current.py
@@ -1,0 +1,42 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, api, fields, models
+
+
+class HrTimesheetCurrentOpen(models.TransientModel):
+    _name = "hr.timesheet.current.open"
+    _description = "hr.timesheet.current.open"
+
+    @api.model
+    def open_timesheet(self):
+        view_type = "form,tree"
+
+        sheets = (
+            self.env["hr_timesheet.sheet"]
+            .sudo()
+            .search(
+                [
+                    ("user_id", "=", self._uid),
+                    ("state", "in", ("draft", "new")),
+                    ("date_start", "<=", fields.Date.today()),
+                    ("date_end", ">=", fields.Date.today()),
+                ]
+            )
+        )
+        if len(sheets) > 1:
+            view_type = "tree,form"
+            domain = "[('id', 'in', " + str(sheets.ids) + "),('user_id', '=', uid)]"
+        else:
+            domain = "[('user_id', '=', uid)]"
+        value = {
+            "domain": domain,
+            "name": _("Open Timesheet"),
+            "view_type": "form",
+            "view_mode": view_type,
+            "res_model": "hr_timesheet.sheet",
+            "view_id": False,
+            "type": "ir.actions.act_window",
+        }
+        if len(sheets) == 1:
+            value["res_id"] = sheets.ids[0]
+        return value


### PR DESCRIPTION
It was standard in version 10.0. It is useful as some companies may create all the timesheets for the current year in advance, making the finding of the current timesheet annoying

cc @ForgeFlow