### PR TITLE
[16.0][IMP] hr_timesheet_begin_end: Change line overlap domain from looking for user to employee

### DIFF
--- a/hr_timesheet_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_begin_end/models/account_analytic_line.py
@@ -54,7 +54,7 @@ class AccountAnalyticLine(models.Model):
             others = self.search(
                 [
                     ("id", "!=", line.id),
-                    ("user_id", "=", line.user_id.id),
+                    ("employee_id", "=", line.employee_id.id),
                     ("date", "=", line.date),
                     ("time_start", "<", line.time_stop),
                     ("time_stop", ">", line.time_start),


### PR DESCRIPTION
With this PR, the only thing I want to change is to replace the user with the employee in the domain. I don't see any logic in checking if the users are the same, since sometimes it can happen that the employee doesn't have a user. In other words, the employee will never be false, whereas the user might be.