### PR TITLE
[14.0][FIX] hr_timesheet_sheet: Don't merge timesheets during onchange

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -373,7 +373,9 @@ class Sheet(models.Model):
             vals_list = []
             for key in sorted(matrix, key=lambda key: sheet._get_matrix_sortby(key)):
                 vals_list.append(sheet._get_default_sheet_line(matrix, key))
-                if sheet.state in ["new", "draft"]:
+                if sheet.state in ["new", "draft"] and self.env.context.get(
+                    "hr_timesheet_sheet_clean_timesheets", True
+                ):
                     sheet.clean_timesheets(matrix[key])
             sheet.line_ids = [(6, 0, SheetLine.create(vals_list).ids)]
 
@@ -508,6 +510,15 @@ class Sheet(models.Model):
                     % (sheet.complete_name,)
                 )
         return super().unlink()
+
+    def onchange(self, values, field_name, field_onchange):
+        """
+        Pass a flag for _compute_line_ids not to clean timesheet lines to be (kind of)
+        idempotent during onchange
+        """
+        return super(
+            Sheet, self.with_context(hr_timesheet_sheet_clean_timesheets=False)
+        ).onchange(values, field_name, field_onchange)
 
     def _get_informables(self):
         """Hook for extensions"""

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -1093,3 +1093,24 @@ class TestHrTimesheetSheet(SavepointCase):
         sheet_form.date_start = date(2019, 12, 29)
         sheet_form.date_end = date(2020, 1, 5)
         self.assertEqual(sheet_form.name, "Weeks 52, 2019 - 01, 2020")
+
+    def test_onchange_project_id_merging_timesheets(self):
+        """Test that we don't try merging timesheets when in onchange"""
+        sheet = Form(self.sheet_model.with_user(self.user)).save()
+        aal1 = self.aal_model.create(
+            {
+                "project_id": self.project_1.id,
+                "date": sheet.date_start,
+                "name": "/",
+                "unit_amount": 1,
+                "employee_id": self.employee.id,
+            }
+        )
+        with Form(sheet) as sheet_form:
+            aal2 = aal1.copy()
+            sheet_form.save()
+            sheet_form.add_line_project_id = self.project_1
+            self.assertTrue(aal1.exists())
+            self.assertTrue(aal2.exists())
+        # but be sure they are merged on save
+        self.assertEqual(len((aal1 + aal2).exists()), 1)


### PR DESCRIPTION
I haven't found a way to trigger this one with the standard UI, but given I'm very probably not the only integrator running into this problem with custom code, I figure it's a good thing to fix it here.

The issue is that _compute_line_ids is also called during onchange, and depending on what analytic lines you have on your form at this point, this breaks (Record does not exist or has been deleted) when Model.onchange reads the timesheets after line_ids has been computed (that's not entirely deterministic), and some analytic lines have been deleted due to merging. The merging happens anyways when saving the form.

If you agree to merge this fix in the base module, I'll cherry pick this PR to the higher branches too. Should make life easier for all integrators.