### PR TITLE
[15.0][IMP] hr_timesheet_sheet_period: add Current Period filter in timesheets

### DIFF
--- a/hr_timesheet_sheet_period/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_sheet_period/views/hr_timesheet_sheet_view.xml
@@ -30,6 +30,29 @@
             <field name="date_start" position="after">
                 <field name="hr_period_id" />
             </field>
+            <xpath expr='//filter[@name="to_review"]' position="after">
+                <separator />
+                <filter
+                    name="current_period"
+                    string="Current Period"
+                    domain="[('hr_period_id.date_start', '&lt;=', datetime.date.today().strftime('%Y-%m-%d')),
+                    ('hr_period_id.date_end', '&gt;=', datetime.date.today().strftime('%Y-%m-%d'))]"
+                />
+                <separator />
+            </xpath>
         </field>
     </record>
+
+    <!-- When seeing all timesheets default to current period -->
+
+    <record
+        id="hr_timesheet_sheet.act_hr_timesheet_sheet_all_timesheets"
+        model="ir.actions.act_window"
+    >
+        <field name="context">{
+            'search_default_current_period': 1
+        }
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
When being a manager and seeing All timesheets for all employees it is useful to filter the ones belonging to the current period:

![image](https://github.com/OCA/timesheet/assets/19620251/fa5f2003-7b13-481f-a873-5a49dfb3eed0)

cc @ForgeFlow