### PR TITLE
[16.0][FIX] hr_timesheet_sheet: Update sheet with time off line

### DIFF
--- a/hr_timesheet_sheet/models/account_analytic_line.py
+++ b/hr_timesheet_sheet/models/account_analytic_line.py
@@ -136,4 +136,7 @@ class AccountAnalyticLine(models.Model):
         return self[0]
 
     def _check_can_update_timesheet(self):
-        return super()._check_can_update_timesheet() or not self.filtered("sheet_id")
+        res = super()._check_can_update_timesheet()
+        if not res and self.filtered("holiday_id"):
+            return True
+        return res


### PR DESCRIPTION
This is a fix for this [issue](https://github.com/OCA/timesheet/pull/580#issuecomment-1538653864) mentioned in the migration PR #580 to version 16.0. 
The error message does not appear anymore, and you can now add new lines or modify existing ones on timesheet sheets that contain holiday lines.
