### PR TITLE
[FIX] hr_timesheet_sheet: fix for assigning reviewers from respective company in multicompany environment

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -344,6 +344,7 @@ class Sheet(models.Model):
             res |= self.env.ref("hr.group_hr_manager").users
         elif self.review_policy == "timesheet_manager":
             res |= self.env.ref("hr_timesheet.group_hr_timesheet_approver").users
+        res = res.filtered(lambda u: self.company_id in u.company_ids)
         return res
 
     def _get_timesheet_sheet_company(self):


### PR DESCRIPTION
This commit would assign reviewers from respective company in multicompany environment only. Right now it assigns users from all companies irrespective of whether the users have access or not to the company in which the timesheet  sheet is created