### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/hr_timesheet_task/__manifest__.py
+++ b/hr_timesheet_task/__manifest__.py
@@ -9,7 +9,7 @@
     'website': 'https://odoo-community.org/',
     'license': 'AGPL-3',
     'version': '10.0.1.0.3',
-    'author': 'Scopea, Niboo, Camptocamp SA, Odoo Community Association (OCA)',
+    'author': 'Scopea, Niboo, Camptocamp, Odoo Community Association (OCA)',
     'depends': ['hr_timesheet_sheet'],
     'data': [
         'views/hr_timesheet_assets.xml',


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 10.0.