### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/sale_project_timesheet_by_seniority/__manifest__.py
+++ b/sale_project_timesheet_by_seniority/__manifest__.py
@@ -7,7 +7,7 @@
         Automatically map employee and sale order line when timesheeting.""",
     'version': '12.0.1.0.0',
     'license': 'AGPL-3',
-    'author': 'Camptocamp SA,Odoo Community Association (OCA)',
+    'author': 'Camptocamp,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/timesheet',
     'depends': [
         'sale_timesheet',


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 12.0.