### PR TITLE
[16.0][IMP] sale_timesheet_line_exclude: add security group

### DIFF
--- a/sale_timesheet_line_exclude/README.rst
+++ b/sale_timesheet_line_exclude/README.rst
@@ -54,6 +54,9 @@ or:
   # Go to *Project > All Tasks*, ans open a specific Task form
   # On the Task form, *Timesheets* tab, check *Non-billable* for specific timesheet entries
 
+To have access to this *Non-billable* field, the user must be added to the 
+*Exclude timesheets from sale order* security group.
+
 Bug Tracker
 ===========
 

--- a/sale_timesheet_line_exclude/__manifest__.py
+++ b/sale_timesheet_line_exclude/__manifest__.py
@@ -13,5 +13,9 @@
     "application": False,
     "summary": "Exclude Timesheet Line from Sale Order",
     "depends": ["sale_timesheet"],
-    "data": ["views/account_analytic_line.xml", "views/project_task.xml"],
+    "data": [
+        "security/exclude_from_sale_order.xml",
+        "views/account_analytic_line.xml",
+        "views/project_task.xml",
+    ],
 }

--- a/sale_timesheet_line_exclude/models/account_analytic_line.py
+++ b/sale_timesheet_line_exclude/models/account_analytic_line.py
@@ -11,6 +11,7 @@ class AccountAnalyticLine(models.Model):
     exclude_from_sale_order = fields.Boolean(
         string="Non-billable",
         help="Checking this would exclude this timesheet entry from Sale Order",
+        groups="sale_timesheet_line_exclude.group_exclude_from_sale_order",
     )
 
     @api.constrains("exclude_from_sale_order")

--- a/sale_timesheet_line_exclude/models/account_analytic_line.py
+++ b/sale_timesheet_line_exclude/models/account_analytic_line.py
@@ -12,6 +12,7 @@ class AccountAnalyticLine(models.Model):
         string="Non-billable",
         help="Checking this would exclude this timesheet entry from Sale Order",
         groups="sale_timesheet_line_exclude.group_exclude_from_sale_order",
+        copy=False,
     )
 
     @api.constrains("exclude_from_sale_order")

--- a/sale_timesheet_line_exclude/readme/USAGE.rst
+++ b/sale_timesheet_line_exclude/readme/USAGE.rst
@@ -7,3 +7,6 @@ or:
 
   # Go to *Project > All Tasks*, ans open a specific Task form
   # On the Task form, *Timesheets* tab, check *Non-billable* for specific timesheet entries
+
+To have access to this *Non-billable* field, the user must be added to the 
+*Exclude timesheets from sale order* security group.

--- a/sale_timesheet_line_exclude/security/exclude_from_sale_order.xml
+++ b/sale_timesheet_line_exclude/security/exclude_from_sale_order.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright ACSONE SA/NV (https://acsone.eu)
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="group_exclude_from_sale_order" model="res.groups">
+        <field name="name">Exclude timesheets from sale order</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+        <field
+            name="comment"
+        >Gives access to the Non-Billable field on timesheets.</field>
+    </record>
+</odoo>

--- a/sale_timesheet_line_exclude/static/description/index.html
+++ b/sale_timesheet_line_exclude/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -398,6 +397,8 @@ excluded from the Sale Order.</p>
 <blockquote>
 # Go to <em>Project &gt; All Tasks</em>, ans open a specific Task form
 # On the Task form, <em>Timesheets</em> tab, check <em>Non-billable</em> for specific timesheet entries</blockquote>
+<p>To have access to this <em>Non-billable</em> field, the user must be added to the
+<em>Exclude timesheets from sale order</em> security group.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>


### PR DESCRIPTION
closes #705 

This should be merged with a minor or major version bump as it adds a security group that will need to be added to relevant users in order to preserve functionality.