### PR TITLE
[FIX] sale_timesheet_line_exclude: recompute so line when changing exclude flag

### DIFF
--- a/sale_timesheet_line_exclude/models/account_analytic_line.py
+++ b/sale_timesheet_line_exclude/models/account_analytic_line.py
@@ -38,8 +38,8 @@ class AccountAnalyticLine(models.Model):
         return res
 
     @api.depends("exclude_from_sale_order")
-    def _compute_so_line_on_exclude(self):
-        self._compute_so_line()
+    def _compute_so_line(self):
+        return super()._compute_so_line()
 
     def _timesheet_determine_sale_line(self):
         self.ensure_one()

--- a/sale_timesheet_line_exclude/tests/test_sale_timesheet_line_exclude.py
+++ b/sale_timesheet_line_exclude/tests/test_sale_timesheet_line_exclude.py
@@ -174,7 +174,9 @@ class TestSaleTimesheetLineExclude(common.TransactionCase):
                 "account_id": self.project.analytic_account_id.id,
             }
         )
+        self.assertTrue(timesheet.so_line)
         timesheet.write({"exclude_from_sale_order": True})
+        self.assertFalse(timesheet.so_line)
 
         self.assertEqual(timesheet.timesheet_invoice_type, "non_billable")
         self.assertEqual(self.sale_order_line.qty_delivered, 0)


### PR DESCRIPTION
While the test does not reveal this, without this change, clicking on the checkbox in the timesheet list view
does not reset the so line.