### PR TITLE
[IMP] hr_employee_cost_history: add comment field in history line

### DIFF
--- a/hr_employee_cost_history/models/hr_employee_timesheet_cost_history.py
+++ b/hr_employee_cost_history/models/hr_employee_timesheet_cost_history.py
@@ -22,3 +22,4 @@ class HrEmployeeTimesheetCostHistory(models.Model):
         help="The cost change has effect since this date.",
         default=fields.Date.context_today,
     )
+    comment = fields.Char()

--- a/hr_employee_cost_history/tests/test_hr_timesheet.py
+++ b/hr_employee_cost_history/tests/test_hr_timesheet.py
@@ -196,3 +196,28 @@ class HrEmployeeCostHistory(TransactionCase):
             )
         last_timesheet = timesheet_cost_ids[-1]
         self.assertEqual(last_timesheet.hourly_cost, 20.0)
+
+    @users("test_user_manager")
+    def test_field_comment(self):
+        """Test comment field."""
+        wizard = Form(
+            self.env["hr.employee.timesheet.cost.wizard"].with_context(
+                default_employee_id=self.employee.id,
+                default_hourly_cost=123,
+                default_starting_date=date.today(),
+                default_comment="Test comment",
+            )
+        )
+        wizard_result = wizard.save()
+        wizard_result.update_employee_cost()
+        comment = (
+            self.env["hr.employee.timesheet.cost.history"]
+            .search(
+                [
+                    ("employee_id", "=", self.employee.id),
+                    ("hourly_cost", "=", 123),
+                ]
+            )
+            .comment
+        )
+        self.assertEqual(comment, "Test comment")

--- a/hr_employee_cost_history/views/hr_employee_timesheet_cost_history_views.xml
+++ b/hr_employee_cost_history/views/hr_employee_timesheet_cost_history_views.xml
@@ -10,6 +10,7 @@
             <tree>
                 <field name="hourly_cost" />
                 <field name="starting_date" />
+                <field name="comment" />
                 <field name="create_uid" optional="hide" />
                 <field name="create_date" optional="hide" />
             </tree>

--- a/hr_employee_cost_history/wizards/hr_employee_timesheet_cost_wizard.py
+++ b/hr_employee_cost_history/wizards/hr_employee_timesheet_cost_wizard.py
@@ -20,6 +20,7 @@ class HrEmployeeTimesheetCost(models.TransientModel):
         default=fields.Datetime.now,
         string="From Date",
     )
+    comment = fields.Char()
 
     @api.model
     def default_get(self, fields):
@@ -54,6 +55,7 @@ class HrEmployeeTimesheetCost(models.TransientModel):
                             "currency_id": self.currency_id.id,
                             "hourly_cost": self.hourly_cost,
                             "starting_date": self.starting_date,
+                            "comment": self.comment,
                         }
                     ),
                 ],

--- a/hr_employee_cost_history/wizards/hr_employee_timesheet_cost_wizard_views.xml
+++ b/hr_employee_cost_history/wizards/hr_employee_timesheet_cost_wizard_views.xml
@@ -17,6 +17,9 @@
                             <field name="starting_date" />
                         </group>
                     </group>
+                    <group>
+                        <field name="comment" />
+                    </group>
                 </sheet>
                 <footer>
                     <button


### PR DESCRIPTION
This PR adds a comment field on the history line to tell why the cost change did happen.

closes #696 

A very small fix has been added for hr_timesheet_name_customer because Odoo has added a new test in sale_timesheet (test_billing_project/test_take_into_account_invoicing_app_legacy) which failed without doing a secure get in vals dict.