### PR TITLE
[16.0][FIX] project_task_stage_allow_timesheet: invoice creation

### DIFF
--- a/project_task_stage_allow_timesheet/models/account_analytic_line.py
+++ b/project_task_stage_allow_timesheet/models/account_analytic_line.py
@@ -16,20 +16,21 @@ class AccountAnalyticLine(models.Model):
 
     @api.constrains("task_id")
     def _check_task_allow_timesheet(self):
-        for rec in self:
-            task = rec.task_id
-            stage = task.stage_id
-            if task and stage and not stage.allow_timesheet:
-                raise ValidationError(
-                    _(
-                        "You can't link a timesheet line to a task if its stage"
-                        " doesn't allow it. (Task: %(task_name)s, Stage: %(stage_name)s)"
+        if self.env.context.get("is_timesheet"):
+            for rec in self:
+                task = rec.task_id
+                stage = task.stage_id
+                if task and stage and not stage.allow_timesheet:
+                    raise ValidationError(
+                        _(
+                            "You can't link a timesheet line to a task if its stage"
+                            " doesn't allow it. (Task: %(task_name)s, Stage: %(stage_name)s)"
+                        )
+                        % {
+                            "task_name": task.display_name,
+                            "stage_name": stage.display_name,
+                        }
                     )
-                    % {
-                        "task_name": task.display_name,
-                        "stage_name": stage.display_name,
-                    }
-                )
 
     @api.model
     def _get_task_domain(self):

--- a/project_task_stage_allow_timesheet/tests/test_project_task_stage_allow_timesheet.py
+++ b/project_task_stage_allow_timesheet/tests/test_project_task_stage_allow_timesheet.py
@@ -31,7 +31,7 @@ class TestProjectTaskStageAllowTimesheet(TransactionCase):
 
         self.stage_new.allow_timesheet = False
         with self.assertRaises(ValidationError) as e, self.env.cr.savepoint():
-            self.AnalyticLine.create(values)
+            self.AnalyticLine.with_context(is_timesheet=1).create(values)
 
         self.assertIn(
             "You can't link a timesheet line to a task if its stage doesn't allow it.",


### PR DESCRIPTION
When the task is in a stage that doesn't allow timesheet you get an error when you want to invoice the timesheet already encoded. This fixes https://github.com/OCA/timesheet/issues/738