### PR TITLE
[16.0][FIX] hr_timesheet_name_customer: better impl with compute

### DIFF
--- a/hr_timesheet_name_customer/models/hr_timesheet_name_customer.py
+++ b/hr_timesheet_name_customer/models/hr_timesheet_name_customer.py
@@ -6,12 +6,15 @@ from odoo import api, fields, models
 class NameCustomer(models.Model):
     _inherit = "account.analytic.line"
 
-    name_customer = fields.Char(string="Customer Description")
-    """override create method, initialize name_customer"""
+    name_customer = fields.Char(
+        string="Customer Description",
+        compute="_compute_name_customer",
+        store=True,
+        readonly=False,
+    )
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            if not vals.get("name_customer"):
-                vals["name_customer"] = vals["name"]
-        return super(NameCustomer, self).create(vals_list)
+    @api.depends("name")
+    def _compute_name_customer(self):
+        for rec in self:
+            if not rec.name_customer and rec.name:
+                rec.name_customer = rec.name


### PR DESCRIPTION
Before this commit, the creation would fail when no 'name' value was provided.