### PR TITLE
[16.0][IMP] hr_timesheet_editable_top: Order by date DESC

### DIFF
--- a/hr_timesheet_editable_top/views/hr_analytic_timesheet.xml
+++ b/hr_timesheet_editable_top/views/hr_analytic_timesheet.xml
@@ -7,6 +7,18 @@
         <field name="arch" type="xml">
             <xpath expr="//tree" position="attributes">
                 <attribute name="editable">top</attribute>
+                <attribute name="default_order">date desc</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_task_form2_inherited" model="ir.ui.view">
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='timesheet_ids']//tree" position="attributes">
+                <attribute name="editable">top</attribute>
+                <attribute name="default_order">date desc</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Sort timesheets by descending date.

cc https://helpdesk.apsl.net/ HT01749

@miquelalzanillas @peluko00 @mpascuall @ppyczko @javierobcn @BernatObrador please review