### PR TITLE
[16.0][FIX]hr_timesheet_sheet: handle new analityc line when previous sheet was confirmed

### DIFF
--- a/hr_timesheet_sheet/models/account_analytic_line.py
+++ b/hr_timesheet_sheet/models/account_analytic_line.py
@@ -9,7 +9,9 @@ from odoo.exceptions import UserError, ValidationError
 class AccountAnalyticLine(models.Model):
     _inherit = "account.analytic.line"
 
-    sheet_id = fields.Many2one(comodel_name="hr_timesheet.sheet", string="Sheet")
+    sheet_id = fields.Many2one(
+        comodel_name="hr_timesheet.sheet", string="Sheet", copy=False
+    )
     sheet_state = fields.Selection(string="Sheet State", related="sheet_id.state")
 
     def _get_sheet_domain(self):


### PR DESCRIPTION
When creating a new line on a project task via the "Start Work", if there is another line which is present in a `hr_timesheet_sheet` in state `confirm` or `done`, the new line will be created by duplicating the last one.

Which means creating a new line with the same `sheet_id`.
The new line is then updated with a new sheet (the corresponding one if there is one, `None` otherwise).
This sheet change triggers the `_check_state` method **before** assigning the new sheet, which raises the error.

Steps to reproduce on runboat:
1. log as admin into baseonly db
2. install `hr_timesheet_sheet` and `project_timesheet_time_control` modules
3. create a new timesheet for the current week (also stop tasks that are currently active)
4. select a task and change one of the lines' day to the last working day of this week
5. confirm timesheet
6. go on the same task where you changed day, click on "Start Work" to create a new line. Let it start in the following week
7. observe error "You cannot modify an entry in a confirmed timesheet sheet"

Expected behavior: you should be able to create a line on the following week, like in version `14.0`