### PR TITLE
[17.0][FIX] hr_timesheet_task_stage: Correctly hide is_task_closed column with column_invisible

### DIFF
--- a/hr_timesheet_task_stage/views/account_analytic_line.xml
+++ b/hr_timesheet_task_stage/views/account_analytic_line.xml
@@ -10,7 +10,7 @@
         <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree" />
         <field name="arch" type="xml">
             <field name="task_id" position="after">
-                <field name="is_task_closed" invisible="1" />
+                <field name="is_task_closed" column_invisible="1" />
                 <button
                     name="action_close_task"
                     title="Close task"


### PR DESCRIPTION
Correctly hide `is_task_closed` column with `column_invisible`.

Please @pilarvargas-tecnativa and @CarlosRoca13 can you review it?

@Tecnativa