### PR TITLE
[17.0][FIX] crm_timesheet: Correctly hide lead_id column with column_invisible

### DIFF
--- a/crm_timesheet/views/hr_timesheet_view.xml
+++ b/crm_timesheet/views/hr_timesheet_view.xml
@@ -6,10 +6,10 @@
         <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree" />
         <field name="arch" type="xml">
             <field name="task_id" position="after">
-                <field name="lead_id" invisible="1" />
+                <field name="lead_id" column_invisible="1" />
                 <field
                     name="lead_id"
-                    invisible="context.get('base_model_name') == 'crm.lead'"
+                    column_invisible="context.get('base_model_name') == 'crm.lead'"
                     groups="sales_team.group_sale_salesman"
                     optional="show"
                 />


### PR DESCRIPTION
Correctly hide `lead_id` column with `column_invisible`.

@Tecnativa