### PR TITLE
[17.0][UPD] hr_timesheet_begin_end: add a hint for project_timesheet_time_control

### DIFF
--- a/hr_timesheet_begin_end/README.rst
+++ b/hr_timesheet_begin_end/README.rst
@@ -30,6 +30,10 @@ Timesheet - Begin/End Hours
 
 Adds starting and ending hours fields on the timesheet activities.
 
+There is also another module
+`project_timesheet_time_control <https://github.com/OCA/project/tree/17.0/project_timesheet_time_control>`__
+with very similar functionality.
+
 **Table of contents**
 
 .. contents::

--- a/hr_timesheet_begin_end/readme/DESCRIPTION.md
+++ b/hr_timesheet_begin_end/readme/DESCRIPTION.md
@@ -1,1 +1,3 @@
 Adds starting and ending hours fields on the timesheet activities.
+
+There is also another module [project_timesheet_time_control](https://github.com/OCA/project/tree/17.0/project_timesheet_time_control) with very similar functionality.

--- a/hr_timesheet_begin_end/static/description/index.html
+++ b/hr_timesheet_begin_end/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -370,6 +371,9 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/timesheet/tree/17.0/hr_timesheet_begin_end"><img alt="OCA/timesheet" src="https://img.shields.io/badge/github-OCA%2Ftimesheet-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/timesheet-17-0/timesheet-17-0-hr_timesheet_begin_end"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/timesheet&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>Adds starting and ending hours fields on the timesheet activities.</p>
+<p>There is also another module
+<a class="reference external" href="https://github.com/OCA/project/tree/17.0/project_timesheet_time_control">project_timesheet_time_control</a>
+with very similar functionality.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -419,7 +423,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
@pedrobaeza I think we should add a hint to project_timesheet_time_control, because this is addressing the same functionality (but is implemented a lot better)

In my opinion hr_timesheet_begin_end should be discontinued/marked as depricated.