### PR TITLE
[17.0][FIX] sale_timesheet_line_exclude: Fixed an error when entering timesheet reports 

### DIFF
--- a/sale_timesheet_line_exclude/README.rst
+++ b/sale_timesheet_line_exclude/README.rst
@@ -77,10 +77,14 @@ Authors
 Contributors
 ------------
 
-- `CorporateHub <https://corporatehub.eu/>`__
+-  `CorporateHub <https://corporatehub.eu/>`__
 
-  - Alexey Pelykh <alexey.pelykh@corphub.eu>
-  - Freni Patel <fpatel@opensourceintegrators.com>
+   -  Alexey Pelykh <alexey.pelykh@corphub.eu>
+   -  Freni Patel <fpatel@opensourceintegrators.com>
+
+-  `APSL-Nagarro <https://apsl.tech>`__
+
+   -  Miquel Pascual <mpascual@apsl.net>
 
 Maintainers
 -----------

--- a/sale_timesheet_line_exclude/__init__.py
+++ b/sale_timesheet_line_exclude/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from . import report

--- a/sale_timesheet_line_exclude/readme/CONTRIBUTORS.md
+++ b/sale_timesheet_line_exclude/readme/CONTRIBUTORS.md
@@ -1,3 +1,5 @@
 - [CorporateHub](https://corporatehub.eu/)
   - Alexey Pelykh \<<alexey.pelykh@corphub.eu>\>
   - Freni Patel \<<fpatel@opensourceintegrators.com>\>
+- [APSL-Nagarro](https://apsl.tech)
+  - Miquel Pascual \<<mpascual@apsl.net>\>

--- a/sale_timesheet_line_exclude/report/__init__.py
+++ b/sale_timesheet_line_exclude/report/__init__.py
@@ -1,0 +1,1 @@
+from . import timesheets_analysis_report

--- a/sale_timesheet_line_exclude/report/timesheets_analysis_report.py
+++ b/sale_timesheet_line_exclude/report/timesheets_analysis_report.py
@@ -1,0 +1,24 @@
+# Copyright 2025 APSL-Nagarro Miquel Pascual
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class TimesheetsAnalysisReport(models.Model):
+    _inherit = "timesheets.analysis.report"
+
+    exclude_from_sale_order = fields.Boolean(
+        string="Non-billable",
+        help="Checking this would exclude this timesheet entry from " "Sale Order",
+        groups="sale_timesheet_line_exclude.group_exclude_from_sale_order",
+        readonly=True,
+    )
+
+    @api.model
+    def _select(self):
+        return (
+            super()._select()
+            + """,
+            A.exclude_from_sale_order AS exclude_from_sale_order
+        """
+        )

--- a/sale_timesheet_line_exclude/static/description/index.html
+++ b/sale_timesheet_line_exclude/static/description/index.html
@@ -425,6 +425,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Freni Patel &lt;<a class="reference external" href="mailto:fpatel&#64;opensourceintegrators.com">fpatel&#64;opensourceintegrators.com</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://apsl.tech">APSL-Nagarro</a><ul>
+<li>Miquel Pascual &lt;<a class="reference external" href="mailto:mpascual&#64;apsl.net">mpascual&#64;apsl.net</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Related to https://github.com/OCA/helpdesk/pull/731 and Issue https://github.com/OCA/helpdesk/issues/730

cc https://github.com/APSL 9141

@miquelalzanillas @lbarry-apsl @javierobcn @peluko00 @BernatObrador @ppyczko please review