### PR TITLE
[17.0][IMP] hr_timesheet_calendar: live value calculation in forms

### DIFF
--- a/hr_timesheet_calendar/README.rst
+++ b/hr_timesheet_calendar/README.rst
@@ -61,13 +61,13 @@ Authors
 Contributors
 ------------
 
-[APSL-Nagarro](https://apsl.tech):
+[APSL-Nagarro](`https://apsl.tech <https://apsl.tech>`__):
 
-- Lansana Barry Sow <lbarry@apsl.net>
+-  Lansana Barry Sow <lbarry@apsl.net>
 
-[glueckkanja AG](https://glueckkanja.com):
+[glueckkanja AG](`https://glueckkanja.com <https://glueckkanja.com>`__):
 
-- Christopher Rogos <crogos@gmail.com>
+-  Christopher Rogos <crogos@gmail.com>
 
 Maintainers
 -----------

--- a/hr_timesheet_calendar/__manifest__.py
+++ b/hr_timesheet_calendar/__manifest__.py
@@ -16,6 +16,7 @@
     ],
     "data": [
         "views/hr_timesheet_views.xml",
+        "views/res_config_settings_view.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/hr_timesheet_calendar/models/__init__.py
+++ b/hr_timesheet_calendar/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import account_analytic_line
+from . import res_config_settings

--- a/hr_timesheet_calendar/models/account_analytic_line.py
+++ b/hr_timesheet_calendar/models/account_analytic_line.py
@@ -1,10 +1,114 @@
-from datetime import datetime
+from datetime import datetime, time, timedelta
+
+import pytz
 
 from odoo import api, fields, models
 
 
 class AccountAnalyticLine(models.Model):
     _inherit = "account.analytic.line"
+
+    @api.model
+    def _get_default_start_time(self):
+        # Set the default start time according to setting to now
+        # or after the previous entry.
+        params = self.env["ir.config_parameter"].sudo()
+        timesheet_alignment = params.get_param(
+            "project_timesheet_time_control.timesheet_alignment"
+        )
+        # default to now
+        now = fields.Datetime.now()
+        start_time = datetime.combine(
+            now.date(), time(hour=now.hour, minute=now.minute, second=0)
+        )
+        if timesheet_alignment == "now":
+            return start_time
+        defaults = self.default_get(["employee_id", "company_id", "date"])
+        date_day = defaults.get("date", now.date())
+        employee_id = defaults.get(
+            "employee_id",
+            self._context.get("default_employee_id", self.env.user.employee_id.id),
+        )
+        if not employee_id:
+            return start_time
+        # get the last entry of the employee on the same day
+        # (searching for date_time_end would be better, but is not working)
+        analytic_lines = self.env[self._name].search(
+            [
+                ["employee_id", "=", employee_id],
+                ["date", "=", date_day],
+                ["date_time", "!=", False],
+            ],
+            order="date_time desc",
+            limit=1,
+        )
+        if analytic_lines.date_time_end:
+            start_time = analytic_lines.date_time_end
+        if not analytic_lines:
+            # if employee has no analytic_lines at this day,
+            # get the employee calendar and set the start time
+            # to the first interval of the day
+            employee = self.env["hr.employee"].browse(employee_id)
+            if employee.resource_calendar_id:
+                start_date = datetime.combine(
+                    date_day, time(0, tzinfo=pytz.timezone(employee.tz))
+                )
+                end_date = start_date + timedelta(days=1)
+                intervals = employee.resource_calendar_id._work_intervals_batch(
+                    start_date, end_date
+                ).get(False, False)
+                if intervals and intervals._items:
+                    start_time = (
+                        intervals._items[0][0].astimezone(pytz.UTC).replace(tzinfo=None)
+                    )
+        return start_time
+
+    date_time = fields.Datetime(
+        string="Start Time", default=_get_default_start_time, copy=False
+    )
+
+    @api.onchange("product_uom_id", "date_time", "date_time_end")
+    def _compute_unit_amount(self):
+        hour_uom = self.env.ref("uom.product_uom_hour")
+        for record in self:
+            if (
+                record.product_uom_id == hour_uom
+                and record.date_time_end
+                and record.date_time
+            ):
+                # When date_time_end or date_time is not set, the unit_amount is updated
+                record.unit_amount = (
+                    record.date_time_end - record.date_time
+                ).total_seconds() / 3600
+
+    @api.model
+    def default_get(self, fields_list):
+        vals = super().default_get(fields_list)
+        if (
+            self._context.get("is_timesheet", False)
+            and "product_uom_id" in fields_list
+            and "product_uom_id" not in vals
+        ):
+            company_id = vals.get("company_id")
+            company = False
+            if company_id:
+                company = self.env["res.company"].browse(company_id)
+            if not company:
+                employee_in_id = vals.get(
+                    "employee_id", self._context.get("default_employee_id", False)
+                )
+                if employee_in_id:
+                    company = self.env["hr.employee"].browse(employee_in_id).company_id
+                else:
+                    company = self.env["res.company"].browse(self.env.company.id)
+
+            if "company_id" in fields_list:
+                vals["company_id"] = company.id
+
+            if company:
+                vals["product_uom_id"] = company.project_time_mode_id.id
+
+        return vals
 
     @api.model
     def duplicate_today(self, record_id):

--- a/hr_timesheet_calendar/models/res_config_settings.py
+++ b/hr_timesheet_calendar/models/res_config_settings.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    timesheet_alignment = fields.Selection(
+        selection=[
+            ("now", "Set Start Date to Now"),
+            ("no-gap", "Align to previous entry"),
+        ],
+        default="now",
+        config_parameter="project_timesheet_time_control.timesheet_alignment",
+        help="Choose the alignment of new timesheet entries without start time.",
+    )

--- a/hr_timesheet_calendar/tests/test_account_analytic_line.py
+++ b/hr_timesheet_calendar/tests/test_account_analytic_line.py
@@ -1,7 +1,9 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from freezegun import freeze_time
 
+from odoo import fields
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
@@ -11,6 +13,15 @@ class TestAccountAnalyticLine(TransactionCase):
         super().setUpClass()
         cls.analytic_line_model = cls.env["account.analytic.line"]
         cls.test_user = cls.env.ref("base.user_admin")
+        cls.employee = cls.env.ref("hr.employee_hne")
+        cls.project = cls.env.ref("project.project_project_2")
+        cls.task = cls.env.ref("project.project_2_task_6")
+
+        cls.analytic_line_model = cls.env["account.analytic.line"]
+        cls.uom_hour = cls.env.ref("uom.product_uom_hour")
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "project_timesheet_time_control.timesheet_alignment", "no-gap"
+        )
 
     @freeze_time("2025-04-03")
     def test_duplicate_today(self):
@@ -63,3 +74,148 @@ class TestAccountAnalyticLine(TransactionCase):
 
         # Assert the new record is not the same as the original
         self.assertNotEqual(new_record.id, analytic_line.id)
+
+    @freeze_time("2025-04-02 12:00:00")
+    def test_get_default_start_time_now(self):
+        """Test the default start time calculation."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "project_timesheet_time_control.timesheet_alignment", "now"
+        )
+        default_start_time = self.analytic_line_model._get_default_start_time()
+        self.assertEqual(default_start_time, datetime(2025, 4, 2, 12, 0, 0))
+
+    @freeze_time("2025-04-02 12:00:00")
+    def test_get_default_start_time_calendar(self):
+        """Test the default start time calculation."""
+        default_start_time = self.analytic_line_model.with_context(
+            default_employee_id=self.employee.id
+        )._get_default_start_time()
+        self.assertEqual(default_start_time, datetime(2025, 4, 2, 6, 0, 0))
+
+    @freeze_time("2025-04-02 12:00:00")
+    def test_create_by_unit_amount(self):
+        """Test the computation of date_time_end based on unit_amount."""
+        # arrange
+        self.analytic_line_model.create(
+            [
+                {
+                    "name": "Test Line",
+                    "employee_id": self.employee.id,
+                    "date_time": datetime(2025, 4, 2, 14, 0, 0),
+                    "date_time_end": datetime(2025, 4, 2, 15, 0, 0),
+                    "product_uom_id": self.uom_hour.id,
+                },
+                {
+                    "name": "Test Line 2",
+                    "employee_id": self.employee.id,
+                    "date_time": datetime(2025, 4, 2, 12, 0, 0),
+                    "date_time_end": datetime(2025, 4, 2, 13, 0, 0),
+                    "product_uom_id": self.uom_hour.id,
+                },
+            ]
+        )
+        # act
+        analytic_line = self.analytic_line_model.with_context(
+            default_employee_id=self.employee.id
+        ).create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "unit_amount": 2,
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        # assert
+        self.assertEqual(analytic_line.date_time, datetime(2025, 4, 2, 15, 0, 0))
+        self.assertEqual(analytic_line.date_time_end, datetime(2025, 4, 2, 17, 0, 0))
+        self.assertEqual(analytic_line.unit_amount, 2)
+
+    def test_compute_date_time_end(self):
+        """Test the computation of date_time_end based on unit_amount."""
+        analytic_line = self.analytic_line_model.create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "date_time": datetime(2025, 4, 2, 12, 0, 0),
+                "unit_amount": 2,
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        self.assertEqual(analytic_line.date_time_end, datetime(2025, 4, 2, 14, 0, 0))
+
+    def test_compute_unit_amount(self):
+        """Test the computation of date_time_end based on unit_amount."""
+        analytic_line = self.analytic_line_model.create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "date_time": datetime(2025, 4, 2, 12, 0, 0),
+                "date_time_end": datetime(2025, 4, 2, 14, 0, 0),
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        self.assertEqual(analytic_line.unit_amount, 2)
+
+    @freeze_time("2025-04-02 12:00:00")
+    def test_button_end_work(self):
+        """Test the button_end_work method."""
+        start_time = fields.Datetime.now()
+        analytic_line = self.analytic_line_model.create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "date_time": start_time,
+                "unit_amount": 0,
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        analytic_line.with_context(
+            stop_dt=start_time + timedelta(hours=2)
+        ).button_end_work()
+        self.assertEqual(analytic_line.unit_amount, 2)
+        self.assertEqual(analytic_line.date_time, datetime(2025, 4, 2, 12, 0, 0))
+
+    def test_button_end_work_error(self):
+        """Test that button_end_work raises an error if the timer is not running."""
+        start_time = fields.Datetime.now()
+        analytic_line = self.analytic_line_model.create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "date_time": start_time,
+                "unit_amount": 2,
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        with self.assertRaises(UserError):
+            analytic_line.button_end_work()
+
+    def test_running_domain(self):
+        """Test the _running_domain method."""
+        domain = self.analytic_line_model._running_domain()
+        self.assertIn(("date_time", "!=", False), domain)
+        self.assertIn(("user_id", "=", self.env.user.id), domain)
+
+    def test_default_get_with_is_timesheet_context(self):
+        """Test default_get method with is_timesheet context."""
+        company = self.env.company
+        company.project_time_mode_id = self.uom_hour
+
+        # Test with employee and is_timesheet context
+        vals = self.analytic_line_model.with_context(
+            is_timesheet=True, default_employee_id=self.employee.id
+        ).default_get(["product_uom_id", "company_id", "employee_id"])
+        self.assertEqual(vals["product_uom_id"], self.uom_hour.id)
+        self.assertEqual(vals["company_id"], company.id)
+
+        # Test with employee and is_timesheet context
+        vals = self.analytic_line_model.with_context(
+            is_timesheet=True, default_employee_id=self.employee.id
+        ).default_get(["product_uom_id", "employee_id"])
+        self.assertEqual(vals["product_uom_id"], self.uom_hour.id)
+        self.assertNotIn("company_id", vals)
+
+        # Test without employee and is_timesheet context
+        vals = self.analytic_line_model.default_get(["product_uom_id"])
+        self.assertNotIn("product_uom_id", vals)
+        self.assertNotIn("company_id", vals)

--- a/hr_timesheet_calendar/views/hr_timesheet_views.xml
+++ b/hr_timesheet_calendar/views/hr_timesheet_views.xml
@@ -18,8 +18,6 @@
             >
                 <field name="project_id" />
                 <field name="task_id" invisible="not task_id" />
-
-
             </calendar>
         </field>
     </record>
@@ -29,5 +27,17 @@
         <field name="sequence" eval="4" />
         <field name="view_id" ref="hr_timesheet_line_calendar" />
         <field name="act_window_id" ref="hr_timesheet.act_hr_timesheet_line" />
+    </record>
+
+    <record id="hr_timesheet_line_form" model="ir.ui.view">
+        <field name="name">account.analytic.line.form.inherit</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form" />
+        <field name="arch" type="xml">
+            <field name="date" position="after">
+                <field name="product_uom_id" invisible="1" />
+                <field name="product_uom_category_id" invisible="1" />
+            </field>
+        </field>
     </record>
 </odoo>

--- a/hr_timesheet_calendar/views/res_config_settings_view.xml
+++ b/hr_timesheet_calendar/views/res_config_settings_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.hr.timesheet</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="hr_timesheet.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//block[@name='time_encoding_setting_container']"
+                position="inside"
+            >
+                <setting
+                    string="Time Connecting"
+                    help="Start the next entry now or without a gap to the previous one."
+                >
+                    <field name="timesheet_alignment" widget="radio" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add two features: 
1. live value calculation in forms, 

1. live value calculation in forms, 
![image](https://github.com/user-attachments/assets/2e834592-f4b7-44cc-8dae-a9e6c836a8ec)

2. start datetime default is now configurable to be **now** or **directly after the previous entry** if available otherwise use employee working hour start. This makes it easier in list view to add multiple lines without gaps.
![image](https://github.com/user-attachments/assets/8ff7c933-e254-4b99-943b-992fa8eb8e0c)

@pilarvargas-tecnativa, @david-banon-tecnativa could you please review? Feedback apricated.


follow up of https://github.com/OCA/project/pull/1486
@lbarry-apsl @david-banon-tecnativa