### PR TITLE
[16.0][FIX]hr_timesheet_sheet_autodraft: fix department in timesheet sheet

### DIFF
--- a/hr_timesheet_sheet_autodraft/models/account_analytic_line.py
+++ b/hr_timesheet_sheet_autodraft/models/account_analytic_line.py
@@ -44,6 +44,7 @@ class AccountAnalyticLine(models.Model):
                 self.company_id, self.date
             ),
             "date_end": HrTimesheetSheet._get_period_end(self.company_id, self.date),
+            "department_id": self.employee_id.department_id.id,
         }
 
     def action_autodraft_timesheet_sheets(self):

--- a/hr_timesheet_sheet_autodraft/tests/test_hr_timesheet_sheet_autodraft.py
+++ b/hr_timesheet_sheet_autodraft/tests/test_hr_timesheet_sheet_autodraft.py
@@ -11,6 +11,7 @@ class TestHrTimesheetSheetAutodraft(common.TransactionCase):
         self.ResUsers = self.env["res.users"]
         self.Company = self.env["res.company"]
         self.Project = self.env["project.project"]
+        self.HrDepartment = self.env["hr.department"]
         self.HrEmployee = self.env["hr.employee"]
         self.HrTimesheetSheet = self.env["hr_timesheet.sheet"]
         self.AccountAnalyticLine = self.env["account.analytic.line"]
@@ -43,7 +44,10 @@ class TestHrTimesheetSheetAutodraft(common.TransactionCase):
                 "company_id": self.company_id.id,
             }
         )
-        employee = self.HrEmployee.create({"name": "Employee", "user_id": user.id})
+        department = self.HrDepartment.create({"name": "Department 1"})
+        employee = self.HrEmployee.create(
+            {"name": "Employee", "user_id": user.id, "department_id": department.id}
+        )
         project = self.Project.create({"name": "Project"})
 
         aal_1 = self.AccountAnalyticLine.create(
@@ -67,6 +71,7 @@ class TestHrTimesheetSheetAutodraft(common.TransactionCase):
         self.assertTrue(aal_1.sheet_id)
         self.assertTrue(aal_2.sheet_id)
         self.assertEqual(aal_1.sheet_id, aal_2.sheet_id)
+        self.assertEqual(aal_1.sheet_id.department_id, employee.department_id)
 
     def test_already_confirmed(self):
         user = self.ResUsers.sudo().create(


### PR DESCRIPTION
When an employee requests some time-off, timesheet sheet is created if it doesn't exist, but sometimes department could be set wrong. By default, it's set with the same department of who approves time-off.

This is not correct, so my fix set department as the same of the employee who requested time-off.

These are the steps to reproduce the bug:
1. Module `hr_timesheet_sheet_autodraft` should be active and Auto-draft Timesheet setting should be checked;
2. Assign department A to employee 1
3. Assign department B to employee 2
4. Make sure project and task are correctly set in the time-off type that will be used for the test;
5. Employee 1 requests time-off;
6. Employee 2 approves time-off;

On approval, a new timesheet will be created for employee 1 with the department of employee 2.
With this fix, timesheet will be created with department of employee 1.