### PR TITLE
[IMP] hr_timesheet_type_non_billable: Now works with helpdesk_ticket aswell

### DIFF
--- a/hr_timesheet_type_non_billable/README.rst
+++ b/hr_timesheet_type_non_billable/README.rst
@@ -74,7 +74,7 @@ Contributors
 
 [APSL-Nagarro](https://apsl.tech):
 
-- Miquel Pascual López <mpascual@apsl.net>
+-  Miquel Pascual López <mpascual@apsl.net>
 
 Maintainers
 -----------

--- a/hr_timesheet_type_non_billable/__manifest__.py
+++ b/hr_timesheet_type_non_billable/__manifest__.py
@@ -14,6 +14,8 @@
         "hr_timesheet",
         "hr_timesheet_time_type",
         "sale_timesheet_line_exclude",
+        "helpdesk_mgmt_timesheet",
+        "helpdesk_timesheet_time_type",
     ],
     "data": [
         "views/project_time_type_view.xml",

--- a/hr_timesheet_type_non_billable/models/__init__.py
+++ b/hr_timesheet_type_non_billable/models/__init__.py
@@ -5,3 +5,4 @@ from . import project_time_type
 from . import account_analytic_line
 from . import project_project
 from . import project_task
+from . import helpdesk_ticket

--- a/hr_timesheet_type_non_billable/models/helpdesk_ticket.py
+++ b/hr_timesheet_type_non_billable/models/helpdesk_ticket.py
@@ -1,0 +1,14 @@
+from odoo import api, models
+
+
+class HelpdeskTicket(models.Model):
+    _inherit = "helpdesk.ticket"
+
+    @api.depends("timesheet_ids.unit_amount", "timesheet_ids.time_type_id.non_billable")
+    def _compute_total_hours(self):
+        for record in self:
+            record.total_hours = sum(
+                line.unit_amount
+                for line in record.timesheet_ids
+                if not line.time_type_id.non_billable
+            )

--- a/hr_timesheet_type_non_billable/tests/test_hr_timesheet_type_non_billable.py
+++ b/hr_timesheet_type_non_billable/tests/test_hr_timesheet_type_non_billable.py
@@ -36,6 +36,14 @@ class TestHrTimesheetTypeNonBillable(TransactionCase):
                 "allocated_hours": 10,
             }
         )
+        cls.ticket = cls.env["helpdesk.ticket"].create(
+            {
+                "name": "Test Ticket",
+                "project_id": cls.project.id,
+                "planned_hours": 8,
+                "description": "Test Helpdesk Ticket",
+            }
+        )
 
     def test_non_billable_timesheet(self):
         self.env["account.analytic.line"].create(
@@ -76,4 +84,39 @@ class TestHrTimesheetTypeNonBillable(TransactionCase):
             self.project.remaining_hours,
             47,
             "Project remaining hours should exclude non-billable timesheets.",
+        )
+
+    def test_helpdesk_ticket_non_billable_timesheet(self):
+        self.env["account.analytic.line"].create(
+            {
+                "employee_id": self.employee.id,
+                "name": "Non-Billable Helpdesk Timesheet",
+                "project_id": self.project.id,
+                "ticket_id": self.ticket.id,
+                "unit_amount": 1,
+                "time_type_id": self.non_billable_type.id,
+            }
+        )
+
+        self.env["account.analytic.line"].create(
+            {
+                "employee_id": self.employee.id,
+                "name": "Billable Helpdesk Timesheet",
+                "project_id": self.project.id,
+                "ticket_id": self.ticket.id,
+                "unit_amount": 2,
+                "time_type_id": self.billable_type.id,
+            }
+        )
+
+        self.assertEqual(
+            self.ticket.total_hours,
+            2,
+            "Helpdesk ticket total hours should exclude non-billable timesheets.",
+        )
+
+        self.assertEqual(
+            self.ticket.remaining_hours,
+            6,
+            "Helpdesk ticket effective hours should only include billable timesheets.",
         )


### PR DESCRIPTION
With this IMP the module also works with helpdesk_ticket, not counting the non-billable timesheets.

cc https://github.com/APSL 11704

@miquelalzanillas @lbarry-apsl @BernatObrador @peluko00 @javierobcn @ppyczko please review