### PR TITLE
[18.0][FIX] hr_timesheet_calendar: tests - missing .id reference for create dict

### DIFF
--- a/hr_timesheet_calendar/tests/test_account_analytic_line.py
+++ b/hr_timesheet_calendar/tests/test_account_analytic_line.py
@@ -34,7 +34,7 @@ class TestAccountAnalyticLine(BaseCommon):
                 "date_time": datetime(2025, 4, 2, 9, 0),
                 "date_time_end": datetime(2025, 4, 2, 17, 0),
                 "project_id": self.project.id,
-                "account_id": self.project.account_id,
+                "account_id": self.project.account_id.id,
                 "employee_id": self.employee.id,
             }
         )
@@ -62,7 +62,7 @@ class TestAccountAnalyticLine(BaseCommon):
                 "date": date(2025, 4, 2),
                 "date_time": datetime(2025, 4, 2, 9, 0),
                 "project_id": self.project.id,
-                "account_id": self.project.account_id,
+                "account_id": self.project.account_id.id,
                 "employee_id": self.employee.id,
             }
         )


### PR DESCRIPTION
Running tests, sometimes an error was raised when demo project has analytic account set. When was unset the problem was hidden.

@lbarry-apsl @CRogos could you check? PR #796 is locked due to this problem IMO