### PR TITLE
[18.0][IMP] hr_timesheet_calendar: default_employee and default_date needed when using 'no-gap'

### DIFF
--- a/hr_timesheet_calendar/models/account_analytic_line.py
+++ b/hr_timesheet_calendar/models/account_analytic_line.py
@@ -67,6 +67,17 @@ class AccountAnalyticLine(models.Model):
         string="Start Time", default=_get_default_start_time, copy=False
     )
 
+    def _add_missing_default_values(self, vals):
+        if "employee_id" in vals:
+            self = self.with_context(default_employee_id=vals["employee_id"])
+        if "date" in vals:
+            self = self.with_context(default_date=vals["date"])
+        elif "date_time" in vals:
+            self = self.with_context(default_date=vals["date_time"].date())
+        elif "date_time_end" in vals:
+            self = self.with_context(default_date=vals["date_time_end"].date())
+        return super()._add_missing_default_values(vals)
+
     @api.onchange("product_uom_id", "date_time", "date_time_end")
     def _compute_unit_amount(self):
         hour_uom = self.env.ref("uom.product_uom_hour")

--- a/hr_timesheet_calendar/tests/test_account_analytic_line.py
+++ b/hr_timesheet_calendar/tests/test_account_analytic_line.py
@@ -122,9 +122,7 @@ class TestAccountAnalyticLine(BaseCommon):
             ]
         )
         # act
-        analytic_line = self.analytic_line_model.with_context(
-            default_employee_id=self.employee.id
-        ).create(
+        analytic_line = self.analytic_line_model.create(
             {
                 "name": "Test Line",
                 "employee_id": self.employee.id,
@@ -133,10 +131,12 @@ class TestAccountAnalyticLine(BaseCommon):
             }
         )
         # assert
+        self.assertEqual(analytic_line.date, date(2025, 4, 2))
         self.assertEqual(analytic_line.date_time, datetime(2025, 4, 2, 15, 0, 0))
         self.assertEqual(analytic_line.date_time_end, datetime(2025, 4, 2, 17, 0, 0))
         self.assertEqual(analytic_line.unit_amount, 2)
 
+    @freeze_time("2025-04-05 12:00:00")
     def test_compute_date_time_end(self):
         """Test the computation of date_time_end based on unit_amount."""
         analytic_line = self.analytic_line_model.create(
@@ -148,6 +148,7 @@ class TestAccountAnalyticLine(BaseCommon):
                 "product_uom_id": self.uom_hour.id,
             }
         )
+        self.assertEqual(analytic_line.date, date(2025, 4, 2))
         self.assertEqual(analytic_line.date_time_end, datetime(2025, 4, 2, 14, 0, 0))
 
     def test_compute_unit_amount(self):


### PR DESCRIPTION
When using the "no-gap" setting and approving Time Off the created timesheet entries are always created on the current date and not on the date of the Time Off.

<img width="1792" height="224" alt="image" src="https://github.com/user-attachments/assets/7e236509-ba89-4d35-b93b-6f4e104ac12b" />

<img width="2526" height="276" alt="image" src="https://github.com/user-attachments/assets/3e513f01-b1e7-4e8a-965d-02ddc9a91e97" />
