### PR TITLE
[IMP] hr_timesheet_sheet: hide already assigned timesheets

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -354,6 +354,7 @@ class Sheet(models.Model):
             ("employee_id", "=", self.employee_id.id),
             ("company_id", "=", self._get_timesheet_sheet_company().id),
             ("project_id", "!=", False),
+            ("sheet_id", "=", False),
         ]
 
     @api.depends("date_start", "date_end")


### PR DESCRIPTION
When creating a new timesheet sheet it hides the timesheets that are already in another timesheet sheet.