### PR TITLE
[18.0][FIX] hr_timesheet_calendar: default date not used in date_time field

### DIFF
--- a/hr_timesheet_calendar/models/account_analytic_line.py
+++ b/hr_timesheet_calendar/models/account_analytic_line.py
@@ -25,6 +25,7 @@ class AccountAnalyticLine(models.Model):
             return start_time
         defaults = self.default_get(["employee_id", "company_id", "date"])
         date_day = defaults.get("date", now.date())
+        start_time = datetime.combine(date_day, start_time.time())
         employee_id = defaults.get(
             "employee_id",
             self._context.get("default_employee_id", self.env.user.employee_id.id),
@@ -44,7 +45,7 @@ class AccountAnalyticLine(models.Model):
         )
         if analytic_lines.date_time_end:
             start_time = analytic_lines.date_time_end
-        if not analytic_lines:
+        elif not analytic_lines:
             # if employee has no analytic_lines at this day,
             # get the employee calendar and set the start time
             # to the first interval of the day

--- a/hr_timesheet_calendar/tests/test_account_analytic_line.py
+++ b/hr_timesheet_calendar/tests/test_account_analytic_line.py
@@ -99,6 +99,38 @@ class TestAccountAnalyticLine(BaseCommon):
         )._get_default_start_time()
         self.assertEqual(default_start_time, datetime(2025, 4, 2, 6, 0, 0))
 
+    @freeze_time("2025-04-05 12:00:00")
+    def test_get_default_start_time_no_working_hours(self):
+        """Test the default start time calculation on days without working hours."""
+        default_start_time = self.analytic_line_model.with_context(
+            default_employee_id=self.employee.id
+        )._get_default_start_time()
+        self.assertEqual(default_start_time, datetime(2025, 4, 5, 12, 0, 0))
+
+    @freeze_time("2025-04-05 12:00:00")
+    def test_get_default_start_time_other_default_day(self):
+        """Test the default start time calculation on days without working hours."""
+        default_start_time = self.analytic_line_model.with_context(
+            default_employee_id=self.employee.id, default_date=date(2025, 4, 1)
+        )._get_default_start_time()
+        self.assertEqual(default_start_time, datetime(2025, 4, 1, 6, 0, 0))
+
+    @freeze_time("2025-04-01 12:00:00")
+    def test_get_default_start_time_no_working_hours_other_default_day(self):
+        """Test the default start time calculation on days without working hours."""
+        default_start_time = self.analytic_line_model.with_context(
+            default_employee_id=self.employee.id, default_date=date(2025, 4, 5)
+        )._get_default_start_time()
+        self.assertEqual(default_start_time, datetime(2025, 4, 5, 12, 0, 0))
+
+    @freeze_time("2025-04-01 12:00:00")
+    def test_get_default_start_time_no_employee_other_default_day(self):
+        """Test the default start time calculation on days without working hours."""
+        default_start_time = self.analytic_line_model.with_context(
+            default_date=date(2025, 4, 5)
+        )._get_default_start_time()
+        self.assertEqual(default_start_time, datetime(2025, 4, 5, 12, 0, 0))
+
     @freeze_time("2025-04-02 12:00:00")
     def test_create_by_unit_amount(self):
         """Test the computation of date_time_end based on unit_amount."""


### PR DESCRIPTION
In some situatins the "date" and "date_time" field of an account_analty_line had a different date value. 

This happend when no employee_id has been provided or the employee has no working intervall on the spcified date, and the date was transfered via the context ("default_date").

Not sure how to reproduce in the community edition but possible in the grid view of the entprise timesheet app.