### PR TITLE
[10.0][FIX] hr_timesheet_sheet_week_start_day: manifest typo

### DIFF
--- a/hr_timesheet_sheet_week_start_day/__manifest__.py
+++ b/hr_timesheet_sheet_week_start_day/__manifest__.py
@@ -8,9 +8,9 @@
     "summary": "Allows to define the week start date for Timesheets at "
                "company level",
     "version": "10.0.1.0.0",
-    "author": "Eficent Business and IT Consulting Services, S.L., "
+    "author": "Eficent Business and IT Consulting Services S.L., "
               "Odoo Community Association (OCA)",
-    "website": "http://www.eficent.com",
+    "website": "https://github.com/OCA/timesheet",
     "category": "Generic",
     "depends": ["hr_timesheet_sheet", "project"],
     "license": "AGPL-3",


### PR DESCRIPTION
`S.L.` is not a company.


<img width="551" height="74" alt="Selection_5035" src="https://github.com/user-attachments/assets/5216021c-8a21-4736-992a-d251e1fab045" />