### PR TITLE
[16.0][FIX]  hr_timesheet_sheet_attendance: Change create method to model_create_multi

### DIFF
--- a/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
@@ -87,21 +87,23 @@ class HrTimesheetSheet(models.Model):
                 )
             )
 
-    @api.model
-    def create(self, vals):
-        res = super(HrTimesheetSheet, self).create(vals)
-        attendances = self.env["hr.attendance"].search(
-            [
-                ("employee_id", "=", res.employee_id.id),
-                ("sheet_id", "=", False),
-                ("check_in", ">=", res.date_start),
-                ("check_in", "<=", res.date_end),
-                "|",
-                ("check_out", "=", False),
-                "&",
-                ("check_out", ">=", res.date_start),
-                ("check_out", "<=", res.date_end),
-            ]
-        )
-        attendances._compute_sheet_id()
-        return res
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        attendances = self.env["hr.attendance"]
+        for res in records:
+            attendances |= self.env["hr.attendance"].search(
+                [
+                    ("employee_id", "=", res.employee_id.id),
+                    ("sheet_id", "=", False),
+                    ("check_in", ">=", res.date_start),
+                    ("check_in", "<=", res.date_end),
+                    "|",
+                    ("check_out", "=", False),
+                    "&",
+                    ("check_out", ">=", res.date_start),
+                    ("check_out", "<=", res.date_end),
+                ]
+            )
+        attendances.sudo()._compute_sheet_id()
+        return records


### PR DESCRIPTION
This method was producing warnings in the log.
We have simply applied the OCA convention of using the new @model_create_multi decorator.