### PR TITLE
[17.0][FIX] hr_timesheet_sheet: prevent deletion of timesheet entries when changing sheet period

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -421,11 +421,6 @@ class Sheet(models.Model):
             domain = sheet._get_timesheet_sheet_lines_domain()
             timesheets = AccountAnalyticLines.search(domain)
             sheet.link_timesheets_to_sheet(timesheets)
-            sheet.timesheet_ids = [(6, 0, timesheets.ids)]
-
-    @api.onchange("date_start", "date_end", "employee_id")
-    def _onchange_scope(self):
-        self._compute_timesheet_ids()
 
     @api.onchange("date_start", "date_end")
     def _onchange_dates(self):
@@ -479,6 +474,7 @@ class Sheet(models.Model):
         for vals in vals_list:
             self._check_employee_user_link(vals)
         res = super().create(vals_list)
+        res._compute_timesheet_ids()
         res.write({"state": "draft"})
         return res
 

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -423,17 +423,10 @@ class TestHrTimesheetSheet(TestHrTimesheetSheetCommon):
             }
         )
         sheet_form = Form(self.sheet_model.with_user(self.user))
-        self.assertEqual(len(sheet_form.line_ids), 7)
-        self.assertEqual(len(sheet_form.timesheet_ids), 1)
-        self.assertTrue(self.aal_model.search([("id", "=", timesheet.id)]))
-
-        timesheets = [x.get("id") for x in sheet_form.timesheet_ids._records]
         sheet = sheet_form.save()
-        # analytic line cleaned up on form save
-        self.assertFalse(self.aal_model.search([("id", "in", timesheets)]))
+        self.assertFalse(timesheet.exists())
         self.assertEqual(len(sheet.line_ids), 0)
         self.assertEqual(len(sheet.timesheet_ids), 0)
-        self.assertFalse(self.aal_model.search([("id", "=", timesheet.id)]))
 
     def test_4(self):
         timesheet_1 = self.aal_model.create(
@@ -521,11 +514,7 @@ class TestHrTimesheetSheet(TestHrTimesheetSheetCommon):
             }
         )
         sheet_form = Form(self.sheet_model.with_user(self.user))
-        timesheets = [x.get("id") for x in sheet_form.timesheet_ids._records]
         sheet = sheet_form.save()
-        sheet.timesheet_ids = [(6, 0, timesheets)]
-        with Form(sheet.with_user(self.user)):
-            pass  # trigger edit and save
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 2)
         line = sheet.line_ids.filtered(lambda line: line.unit_amount != 0.0)
@@ -617,11 +606,7 @@ class TestHrTimesheetSheet(TestHrTimesheetSheetCommon):
             }
         )
         sheet_form = Form(self.sheet_model.with_user(self.user))
-        timesheets = [x.get("id") for x in sheet_form.timesheet_ids._records]
         sheet = sheet_form.save()
-        sheet.timesheet_ids = [(6, 0, timesheets)]
-        with Form(sheet.with_user(self.user)):
-            pass  # trigger edit and save
         self.assertEqual(len(sheet.line_ids), 7)
         self.assertEqual(len(sheet.timesheet_ids), 5)
         line = sheet.line_ids.filtered(lambda line: line.unit_amount != 0.0)
@@ -799,11 +784,7 @@ class TestHrTimesheetSheet(TestHrTimesheetSheetCommon):
             }
         )
         sheet_form = Form(self.sheet_model.with_user(self.user))
-        timesheets = [x.get("id") for x in sheet_form.timesheet_ids._records]
         sheet = sheet_form.save()
-        sheet.timesheet_ids = [(6, 0, timesheets)]
-        with Form(sheet.with_user(self.user)):
-            pass  # trigger edit and save
         self.assertEqual(len(sheet.timesheet_ids), 2)
         self.assertEqual(len(sheet.line_ids), 7)
 
@@ -851,11 +832,7 @@ class TestHrTimesheetSheet(TestHrTimesheetSheetCommon):
             }
         )
         sheet_form = Form(self.sheet_model.with_user(self.user))
-        timesheets = [x.get("id") for x in sheet_form.timesheet_ids._records]
         sheet = sheet_form.save()
-        sheet.timesheet_ids = [(6, 0, timesheets)]
-        with Form(sheet.with_user(self.user)):
-            pass  # trigger edit and save
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertEqual(len(sheet.line_ids), 7)
 
@@ -933,11 +910,7 @@ class TestHrTimesheetSheet(TestHrTimesheetSheetCommon):
         )
         self.assertNotEqual(self.company, self.company_2)
         sheet_form = Form(self.sheet_model.with_user(self.user))
-        timesheets = [x.get("id") for x in sheet_form.timesheet_ids._records]
         sheet = sheet_form.save()
-        sheet.timesheet_ids = [(6, 0, timesheets)]
-        with Form(sheet.with_user(self.user)):
-            pass  # trigger edit and save
         self.assertEqual(sheet.company_id, self.company)
         self.assertEqual(len(sheet.timesheet_ids), 1)
         self.assertEqual(sheet.timesheet_ids.company_id, self.company)


### PR DESCRIPTION
When creating a new Timesheet Sheet, **changing the period** will trigger the **method _onchange_scope()** which calls **_compute_timesheet_ids()** that at every execution sets the **timesheets** : **Delete** the existing ones and Link new timesheets. 
After that timesheets will be removed from the project too. 

Issue Ref #847