### PR TITLE
[17.0][FIX] hr_timesheet_sheet: don't block the change of period

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -354,7 +354,7 @@ class Sheet(models.Model):
             ("employee_id", "=", self.employee_id.id),
             ("company_id", "=", self._get_timesheet_sheet_company().id),
             ("project_id", "!=", False),
-            ("sheet_id", "=", False),
+            ("sheet_id", "in", [self.id, False]),
         ]
 
     @api.depends("date_start", "date_end")
@@ -479,6 +479,14 @@ class Sheet(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             self._check_employee_user_link(vals)
+            if "timesheet_ids" in vals:
+                timesheets = vals["timesheet_ids"]
+                filtered_timesheets = []
+                for val in timesheets:
+                    if val[0] != 2:
+                        # deleting Delete commands that may appear when changing period
+                        filtered_timesheets.append(val)
+                vals["timesheet_ids"] = filtered_timesheets
         res = super().create(vals_list)
         res.write({"state": "draft"})
         return res

--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -703,6 +703,26 @@ class TestHrTimesheetSheet(TestHrTimesheetSheetCommon):
         sheet_form.save()
         # self assert something
 
+    def test_change_period_with_existing_sheet_line(self):
+        date_line = self.sheet_model._default_date_start() + relativedelta(days=4)
+        analytic_line = self.aal_model.create(
+            {
+                "name": self.project_1.name,
+                "employee_id": self.employee.id,
+                "company_id": self.company.id,
+                "project_id": self.project_1.id,
+                "date": date_line,
+            }
+        )
+        sheet_form = Form(self.sheet_model.with_user(self.user))
+        self.assertEqual(len(sheet_form.line_ids), 7)
+        self.assertEqual(len(sheet_form.timesheet_ids), 1)
+        sheet_form.date_end = sheet_form.date_start + relativedelta(days=2)
+        self.assertEqual(len(sheet_form.line_ids), 0)
+        self.assertEqual(len(sheet_form.timesheet_ids), 0)
+        sheet_form.save()
+        self.assertTrue(analytic_line.exists())
+
     def test_no_copy(self):
         sheet = Form(self.sheet_model.with_user(self.user)).save()
         with self.assertRaises(UserError):


### PR DESCRIPTION
When you are creating the sheet, it automatically creates sheet lines for the existing analytic lines. But if you change the sheet period before saving, don't delete those analytic lines.

How to trigger the error (easy way):

- Create a time-off for a day of this week.
- Approve the time-off.
- Start to create timesheet sheet (don't save it). Note that a sheet line has been create for that time-off.
- Change the sheet period to the previous week (first change the start date, then the end date). Note that the sheet line for the time-off is not visible anymore.
- Try to save the sheet, but a blocker is shown instead:
<img width="673" height="216" alt="Selection_5321" src="https://github.com/user-attachments/assets/d0682bd1-9d82-41d8-bd93-0b6a32399679" />