### PR TITLE
[FIX] project_task_analytic_propagation: set analytic account for new task created from Tasks

### DIFF
--- a/project_task_analytic_propagation/models/project_task.py
+++ b/project_task_analytic_propagation/models/project_task.py
@@ -25,7 +25,7 @@ class ProjectTask(models.Model):
     @api.depends(lambda self: self._get_project_analytic_plan_columns())
     def _compute_task_analytic_accounts(self):
         plan_fnames = self._get_plan_fnames()
-        for task in self._origin:
+        for task in self._origin or self:
             # By using _origin, new records (with a NewId) are excluded and
             # the computation works automagically for virtual onchange records as well
             task_analytic_accounts = {}


### PR DESCRIPTION
If you create a task from tasks (not from a project) and in this moment (before save task) assign the project, the analytic accounts are not set up in the task.

With this small fix, creating a task from Tasks and then filling in the project field will correctly propagate the analytic account to the new task.

<img width="1274" height="1111" alt="image" src="https://github.com/user-attachments/assets/8bbc2ffd-b0ac-4411-a136-ef3dcf91b94d" />
<img width="1271" height="1109" alt="image" src="https://github.com/user-attachments/assets/274c158e-e1ca-49a9-97bb-e0505f7184fd" />

MT-13452
kas @moduon