### PR TITLE
[18.0] [FIX] hr_timesheet_begin_end: Validate 'overlap' on employee instead of user

### DIFF
--- a/hr_timesheet_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_begin_end/models/account_analytic_line.py
@@ -54,7 +54,7 @@ class AccountAnalyticLine(models.Model):
             others = self.search(
                 [
                     ("id", "!=", line.id),
-                    ("user_id", "=", line.user_id.id),
+                    ("employee_id", "=", line.employee_id.id),
                     ("date", "=", line.date),
                     ("time_start", "<", line.time_stop),
                     ("time_stop", ">", line.time_start),


### PR DESCRIPTION
The validation for overlapping times was done on user_id, which is the user entering the lines. This should be on employee_id, the employee *for who* the times are entered.
This is relevant when entering times within a Task or within 'All Timesheets'

@guewen @luismontalba @ernestotejeda @ivs-cetmix 