### PR TITLE
[18.0][FIX] hr_timesheet_sheet: recompute sheet lines when timesheet changes

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -357,7 +357,14 @@ class Sheet(models.Model):
             ("project_id", "!=", False),
         ]
 
-    @api.depends("date_start", "date_end")
+    @api.depends(
+        "date_start",
+        "date_end",
+        "timesheet_ids.unit_amount",
+        "timesheet_ids.project_id",
+        "timesheet_ids.task_id",
+        "timesheet_ids.date",
+    )
     def _compute_line_ids(self):
         SheetLine = self.env["hr_timesheet.sheet.line"]
         for sheet in self:


### PR DESCRIPTION
Issue: https://github.com/OCA/web/issues/3417
Before the fix:

https://github.com/user-attachments/assets/39f5e062-e93e-4cc9-addf-c3c6190b38e5


After the fix:
https://github.com/user-attachments/assets/6a1c0322-9b61-4898-b6bf-7570923d108c

