### PR TITLE
[18.0][FIX] hr_timesheet_sheet: error when no employee

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -229,7 +229,7 @@ class Sheet(models.Model):
     def _get_complete_name_components(self):
         """Hook for extensions"""
         self.ensure_one()
-        return [self.employee_id.display_name]
+        return [self.employee_id.display_name or ""]
 
     def _get_overlapping_sheet_domain(self):
         """Hook for extensions"""


### PR DESCRIPTION
Step to test:
1. Install module hr_timesheet_sheet
2. create new user **without employee**
3. create new on My Timesheet Sheets, it's error

```
File "/opt/odoo/auto/addons/hr_timesheet_sheet/models/hr_timesheet_sheet.py", line 216, in _compute_complete_name
    ", ".join(complete_name_components),
TypeError: sequence item 0: expected str instance, bool found
```