### PR TITLE
[18.0][FIX] hr_timesheet_sheet: remove global leaves in test setup

### DIFF
--- a/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/tests/test_hr_timesheet_sheet.py
@@ -21,6 +21,10 @@ class TestHrTimesheetSheetCommon(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # Remove global leaves from other modules to avoid test interference
+        cls.env["resource.calendar.leaves"].search(
+            [("resource_id", "=", False)]
+        ).sudo().unlink()
         cls.sheet_model = cls.env["hr_timesheet.sheet"]
         cls.sheet_line_model = cls.env["hr_timesheet.sheet.line"]
         cls.project_model = cls.env["project.project"]


### PR DESCRIPTION
### Problem
When `hr_holidays` is installed, 7 lines appear in the timesheet sheet due to registered public calendar leaves. This causes the test to fail:
<img width="1016" height="160" alt="image" src="https://github.com/user-attachments/assets/82bc6383-89d5-4295-be04-5610818bf86a" />
### Solution

Clean global calendar leaves in `setUpClass` to ensure tests run independently of other installed modules.