### PR TITLE
[15.0][FIX] hr_timesheet_sheet_attendance: Fix timezone handling when linking attendances

### DIFF
--- a/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import pytz
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -90,17 +92,29 @@ class HrTimesheetSheet(models.Model):
     @api.model
     def create(self, vals):
         res = super(HrTimesheetSheet, self).create(vals)
+        tz_name = res.employee_id.user_id.partner_id.tz or "UTC"
+        employee_tz = pytz.timezone(tz_name)
+        date_start_utc = (
+            employee_tz.localize(datetime.combine(res.date_start, datetime.min.time()))
+            .astimezone(pytz.utc)
+            .replace(tzinfo=None)
+        )
+        date_end_utc = (
+            employee_tz.localize(datetime.combine(res.date_end, datetime.max.time()))
+            .astimezone(pytz.utc)
+            .replace(tzinfo=None)
+        )
         attendances = self.env["hr.attendance"].search(
             [
                 ("employee_id", "=", res.employee_id.id),
                 ("sheet_id", "=", False),
-                ("check_in", ">=", res.date_start),
-                ("check_in", "<=", res.date_end),
+                ("check_in", ">=", date_start_utc),
+                ("check_in", "<=", date_end_utc),
                 "|",
                 ("check_out", "=", False),
                 "&",
-                ("check_out", ">=", res.date_start),
-                ("check_out", "<=", res.date_end),
+                ("check_out", ">=", date_start_utc),
+                ("check_out", "<=", date_end_utc),
             ]
         )
         attendances._compute_sheet_id()

--- a/hr_timesheet_sheet_attendance/tests/test_hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_attendance/tests/test_hr_timesheet_sheet.py
@@ -123,6 +123,24 @@ class TestHrTimesheetSheet(HrTimesheetTestCases):
             \nMethod: action_timesheet_confirm",
         )
 
+    def test_02_check_timesheet_compute_old_attendance_timezone(self):
+        """sheet_id should be set for attendances created before the sheet
+        when check_in UTC falls before date_start midnight due to timezone offset"""
+        self.user_id.tz = "Europe/Brussels"
+        # 2019-01-14 23:30 UTC = 2019-01-15 00:30 Europe/Brussels (UTC+1)
+        attendance = self._create_attendance(
+            employee=self.employee,
+            checkIn=datetime.datetime(2019, 1, 14, 23, 30, 0),
+        )
+        time_sheet = self._create_timesheet_sheet(
+            self.employee, datetime.date(2019, 1, 15)
+        )
+        self.assertEqual(
+            attendance.sheet_id,
+            time_sheet,
+            "Attendance with UTC check_in before date_start midnight should be linked",
+        )
+
     def test_03_sighin_sighout(self):
         """test Check In/Check Out button on timesheet-sheet"""
         time_sheet = self._create_timesheet_sheet(self.employee)


### PR DESCRIPTION
A fix was proposed in https://github.com/OCA/timesheet/pull/845/ but this one goes more straight to the point IMHO.

  Root cause: The retroactive linking in HrTimesheetSheet.create() compared the UTC-stored check_in datetime against bare dates using midnight UTC as boundary. For UTC-negative timezones, any check-in on        
  date_end (e.g. 17:57 UTC) fails check_in <= date_end 00:00 UTC. 

Steps to reproduce:

  1. Create an employee with timezone set to a UTC-negative timezone (e.g. America/New_York)                                                                                                                       
  2. Create an attendance for that employee with check_in on the last day of the intended sheet period (e.g. Sunday), at any normal working hour
  3. Create a timesheet sheet covering that period after the attendance was created                                                                                                                                
  4. Observe that the attendance is not linked to the sheet (sheet_id is empty)                                                                                                                                    
                                                                                                                                                                                                                   
