### PR TITLE
[FIX] Apply user timezone to attendance search range

### DIFF
--- a/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
@@ -1,5 +1,6 @@
-import pytz
 from datetime import datetime, time
+
+import pytz
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -95,12 +96,16 @@ class HrTimesheetSheet(models.Model):
         attendances = self.env["hr.attendance"]
         user_tz = pytz.timezone(self.env.user.tz or "UTC")
         for res in records:
-            date_start = user_tz.localize(
-                datetime.combine(res.date_start, time.min)
-            ).astimezone(pytz.UTC).replace(tzinfo=None)
-            date_end = user_tz.localize(
-                datetime.combine(res.date_end, time.max)
-            ).astimezone(pytz.UTC).replace(tzinfo=None)
+            date_start = (
+                user_tz.localize(datetime.combine(res.date_start, time.min))
+                .astimezone(pytz.UTC)
+                .replace(tzinfo=None)
+            )
+            date_end = (
+                user_tz.localize(datetime.combine(res.date_end, time.max))
+                .astimezone(pytz.UTC)
+                .replace(tzinfo=None)
+            )
             attendances |= self.env["hr.attendance"].search(
                 [
                     ("employee_id", "=", res.employee_id.id),

--- a/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+import pytz
+from datetime import datetime, time
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -92,18 +93,25 @@ class HrTimesheetSheet(models.Model):
     def create(self, vals_list):
         records = super().create(vals_list)
         attendances = self.env["hr.attendance"]
+        user_tz = pytz.timezone(self.env.user.tz or "UTC")
         for res in records:
+            date_start = user_tz.localize(
+                datetime.combine(res.date_start, time.min)
+            ).astimezone(pytz.UTC).replace(tzinfo=None)
+            date_end = user_tz.localize(
+                datetime.combine(res.date_end, time.max)
+            ).astimezone(pytz.UTC).replace(tzinfo=None)
             attendances |= self.env["hr.attendance"].search(
                 [
                     ("employee_id", "=", res.employee_id.id),
                     ("sheet_id", "=", False),
-                    ("check_in", ">=", res.date_start),
-                    ("check_in", "<=", res.date_end),
+                    ("check_in", ">=", date_start),
+                    ("check_in", "<=", date_end),
                     "|",
                     ("check_out", "=", False),
                     "&",
-                    ("check_out", ">=", res.date_start),
-                    ("check_out", "<=", res.date_end),
+                    ("check_out", ">=", date_start),
+                    ("check_out", "<=", date_end),
                 ]
             )
         attendances.sudo()._compute_sheet_id()


### PR DESCRIPTION
## Summary

This PR updates the attendance search range in `hr_timesheet_sheet_attendance` to use the current user's timezone when converting sheet start and end dates into datetime values.

Previously, `date_start` and `date_end` were compared directly against `check_in` and `check_out` datetime fields, which could lead to missing attendance records because sheet dates are stored as date values while attendance fields are stored in UTC datetime.

## Changes

* Import `pytz` and `time`
* Convert `date_start` to local start of day (`00:00:00`)
* Convert `date_end` to local end of day (`23:59:59.999999`)
* Apply the current user's timezone before converting the values to UTC
* Use the converted datetime range in the attendance search domain

## Result

Attendance records are now correctly matched to the timesheet sheet date range according to the user's local timezone.
