### PR TITLE
[FIX] hr_timesheet_sheet_attendance: allow checking out to plain atte…

### DIFF
--- a/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_attendance/models/hr_timesheet_sheet.py
@@ -65,7 +65,7 @@ class HrTimesheetSheet(models.Model):
         perform Check In/Check Out action
         Returns last attendance record"""
 
-        return self.employee_id._attendance_action_change()
+        return self.employee_id.attendance_manual(None)
 
     def action_timesheet_confirm(self):
         self.check_employee_attendance_state()


### PR DESCRIPTION
…ndance users

The  previous version,  implemented around  _attendance_action_change, allowed checking  in but not  checking out, which raised  a permission denied  error. Using  attendance_manual takes  care of  the permission issues and also avoid depending on a private function.