### PR TITLE
[17.0][IMP] crm_timesheet: compute partner_id for analytic line from crm.lead

### DIFF
--- a/crm_timesheet/models/account_analytic_line.py
+++ b/crm_timesheet/models/account_analytic_line.py
@@ -18,3 +18,12 @@ class AccountAnalyticLine(models.Model):
     def _onchange_lead_id(self):
         if self.lead_id.project_id:
             self.project_id = self.lead_id.project_id.id
+
+    @api.depends("lead_id.partner_id")
+    def _compute_partner_id(self):
+        # Use lead partner if any
+        self_with_partner = self.filtered("lead_id.partner_id")
+        for line in self_with_partner:
+            line.partner_id = line.lead_id.partner_id
+        self -= self_with_partner
+        return super()._compute_partner_id()

--- a/crm_timesheet/tests/test_account_analytic_line.py
+++ b/crm_timesheet/tests/test_account_analytic_line.py
@@ -79,3 +79,13 @@ class AccountAnalyticLineCase(TransactionCase):
         )
         line._onchange_lead_id()
         self.assertEqual(line.project_id, self.project1)
+
+    def test_compute_partner_id(self):
+        line = (
+            self.env["account.analytic.line"]
+            .sudo()
+            .create({"name": "test", "lead_id": self.lead.id})
+        )
+        self.assertFalse(line.partner_id)
+        self.lead.partner_id = self.env["res.partner"].create({"name": "Test Partner"})
+        self.assertEqual(line.partner_id, self.lead.partner_id)


### PR DESCRIPTION
cc @Tecnativa TT61909
ping @pedrobaeza @david-banon-tecnativa 

This follow this same logic https://github.com/odoo/odoo/blob/ac72e930569fa95474e24a7550cad61e053c2e37/addons/hr_timesheet/models/hr_timesheet.py#L132 

So `partner_id` for timesheet is align with the `crm.lead` one 
