### PR TITLE
[FIX] hr_timesheet_sheet: fix project company domain

### DIFF
--- a/hr_timesheet_sheet/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet/models/hr_timesheet_sheet.py
@@ -131,7 +131,10 @@ class Sheet(models.Model):
     add_line_project_id = fields.Many2one(
         comodel_name="project.project",
         string="Select Project",
-        domain="[('company_id', '=', company_id), ('allow_timesheets', '=', True)]",
+        domain=(
+            "['|', ('company_id', '=', False), ('company_id', '=', company_id), "
+            "('allow_timesheets', '=', True)]"
+        ),
         help="If selected, the associated project is added "
         "to the timesheet sheet when clicked the button.",
     )


### PR DESCRIPTION
A simple fix to also show projects without company when adding a line.