### PR TITLE
[19.0][IMP] hr_timesheet_time_control: use overwritable _get_default_start_time instead of now()

### DIFF
--- a/hr_timesheet_time_control/models/account_analytic_line.py
+++ b/hr_timesheet_time_control/models/account_analytic_line.py
@@ -19,6 +19,10 @@ class AccountAnalyticLine(models.Model):
 
     @api.model
     def _get_default_start_time(self):
+        if default_date := self.env.context.get("default_date"):
+            if isinstance(default_date, str):
+                default_date = fields.Date.from_string(default_date)
+            return datetime.combine(default_date, fields.Datetime.now().time())
         return fields.Datetime.now()
 
     date_time = fields.Datetime(
@@ -73,9 +77,9 @@ class AccountAnalyticLine(models.Model):
         if vals.get("date") and not vals.get("date_time"):
             return dict(
                 vals,
-                date_time=datetime.combine(
-                    fields.Date.to_date(vals["date"]), fields.Datetime.now().time()
-                ),
+                date_time=self.with_context(
+                    default_date=vals["date"]
+                )._get_default_start_time(),
             )
         if vals.get("date_time"):
             return dict(vals, date=self._convert_datetime_to_date(vals["date_time"]))


### PR DESCRIPTION
Enables this improvement

https://github.com/OCA/timesheet/pull/898/changes#diff-80578aa21eaf146a51deebf234a643365172faac18e007e5c4d407a213168dfaR67-R83