### PR TITLE
[19.0][IMP] hr_timesheet_time_control_begin_end: handle str default_date_time in default_get

### DIFF
--- a/hr_timesheet_time_control_begin_end/models/account_analytic_line.py
+++ b/hr_timesheet_time_control_begin_end/models/account_analytic_line.py
@@ -109,8 +109,9 @@ class AccountAnalyticLine(models.Model):
             "default_date"
         ):
             ctx = dict(self.env.context)
-            default_date_time = self.env.context.get("default_date_time")
-            if default_date_time:
+            if default_date_time := self.env.context.get("default_date_time"):
+                if isinstance(default_date_time, str):
+                    default_date_time = fields.Datetime.from_string(default_date_time)
                 ctx["default_date"] = default_date_time.date()
         vals = super(AccountAnalyticLine, self.with_context(**ctx)).default_get(
             fields_list + ["product_uom_id"]

--- a/hr_timesheet_time_control_begin_end/tests/test_account_analytic_line.py
+++ b/hr_timesheet_time_control_begin_end/tests/test_account_analytic_line.py
@@ -172,8 +172,8 @@ class TestAccountAnalyticLine(BaseCommon):
                 is_timesheet=1,
                 default_employee_id=self.employee.id,
                 is_my_timesheets=1,
-                default_date_time=datetime(2025, 10, 20, 3, 15, 0),
-                default_date_time_end=datetime(2025, 10, 20, 7, 0, 0),
+                default_date_time="2025-10-20 03:15:00",
+                default_date_time_end="2025-10-20 07:00:00",
                 default_time_start=5.25,  # compatibility with hr_timesheet_begin_end
                 default_time_stop=9.0,  # compatibility with hr_timesheet_begin_end
             ),


### PR DESCRIPTION
@pedrobaeza when useing [hr_timesheet_calendar](https://github.com/OCA/timesheet/pull/898) and hr_timesheet_time_control_begin_end the default_date_time in the context comming from the calendar is str not datetime. 
Therefore the change we recently did https://github.com/OCA/timesheet/pull/899/changes is not working.

This error occurs when creating a new entry in the calendar view. [runboat](https://github.com/OCA/timesheet/pull/898)
<img width="1942" height="1090" alt="image" src="https://github.com/user-attachments/assets/1e41bd38-111a-4ee5-891d-61711485e05a" />

Therefore I would like to re-add the string handling. 
Another possible solution would be to make hr_timesheet_calendar dependent of hr_timesheet_time_control_begin_end instead of hr_timesheet_time_control. In this case the execution order is correct and the str can be handled in hr_timesheet_calendar. (but I prefer adding the str handling here).

What do you think?