### PR TITLE
[IMP] sale_timesheet_invoice_link: link pending timesheets from invoice form

### DIFF
--- a/sale_timesheet_invoice_link/README.rst
+++ b/sale_timesheet_invoice_link/README.rst
@@ -36,6 +36,10 @@ This module extends the functionality of timesheets to support linking
 them to preexisting invoices and to allow you to anticipate invoicing,
 even before the work hours are actually done.
 
+It also adds a warning alert on invoices that detects timesheets linked
+to the invoice's sale order lines that are not yet linked to any
+invoice, allowing you to link them all at once or select them manually.
+
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
    Only for development or testing purpose, do not use in production.
@@ -78,6 +82,17 @@ To use this module, you need to:
 4. Link the timesheet lines with the invoices you want from the same
    customer.
 
+Additionally, when you open an invoice that has timesheets linked to its
+sale order lines but not yet linked to the invoice itself, a warning
+alert will appear at the top of the invoice form. From there you can:
+
+- Click **Link All** to automatically link all pending timesheets to
+  this invoice.
+- Click **Select Manually** to open a filtered list of pending
+  timesheets where you can select specific ones and click **Link to
+  Invoice**.
+- Click **Dismiss** to hide the alert for this invoice.
+
 Known issues / Roadmap
 ======================
 
@@ -106,6 +121,7 @@ Contributors
 ------------
 
 - Jairo Llopis (`Moduon <https://www.moduon.team/>`__)
+- Emilio Pascual (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 -----------

--- a/sale_timesheet_invoice_link/__init__.py
+++ b/sale_timesheet_invoice_link/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_timesheet_invoice_link/__manifest__.py
+++ b/sale_timesheet_invoice_link/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Timesheet Invoice Link",
     "summary": "Link invoices with timesheet lines",
-    "version": "19.0.0.1.1",
+    "version": "19.0.0.1.0",
     "development_status": "Alpha",
     "category": "Services/Timesheets",
     "website": "https://github.com/OCA/timesheet",
@@ -14,5 +14,6 @@
     "depends": ["sale_timesheet"],
     "data": [
         "views/account_analytic_line_view.xml",
+        "views/account_move_view.xml",
     ],
 }

--- a/sale_timesheet_invoice_link/i18n/es.po
+++ b/sale_timesheet_invoice_link/i18n/es.po
@@ -4,26 +4,28 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 19.0+e\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-07-27 06:22+0000\n"
-"PO-Revision-Date: 2026-07-27 06:22+0000\n"
-"Last-Translator: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Emilio Pascual <emilio@moduon.team>\n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: sale_timesheet_invoice_link
 #: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_link.account_move_view_form_inherit_timesheet_link
 msgid "Dismiss"
-msgstr ""
+msgstr "Descartar"
 
 #. module: sale_timesheet_invoice_link
 #: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_link.account_move_view_form_inherit_timesheet_link
 msgid "Dismiss this alert"
-msgstr ""
+msgstr "Ignorar esta alerta"
 
 #. module: sale_timesheet_invoice_link
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_link.field_account_move__display_name
@@ -40,44 +42,45 @@ msgstr ""
 #: model:ir.model.fields,help:sale_timesheet_invoice_link.field_account_move__timesheet_alert_dismissed
 msgid "If unchecked, shows a warning alert about unlinked timesheets"
 msgstr ""
+"Si está desmarcado, muestra una alerta sobre partes de horas no vinculados"
 
 #. module: sale_timesheet_invoice_link
 #: model:ir.model,name:sale_timesheet_invoice_link.model_account_move
 msgid "Journal Entry"
-msgstr ""
+msgstr "Asiento contable"
 
 #. module: sale_timesheet_invoice_link
 #: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_link.account_move_view_form_inherit_timesheet_link
 msgid "Link All"
-msgstr ""
+msgstr "Vincular todos"
 
 #. module: sale_timesheet_invoice_link
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_link.field_account_bank_statement_line__timesheet_pending_ids
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_link.field_account_move__timesheet_pending_ids
 msgid "Pending Timesheets"
-msgstr ""
+msgstr "Partes de horas pendientes"
 
 #. module: sale_timesheet_invoice_link
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_link.field_account_bank_statement_line__timesheet_pending_count
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_link.field_account_move__timesheet_pending_count
 msgid "Pending Timesheets Count"
-msgstr ""
+msgstr "N.º de partes de horas pendientes"
 
 #. module: sale_timesheet_invoice_link
 #: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_link.account_move_view_form_inherit_timesheet_link
 msgid "Select Manually"
-msgstr ""
+msgstr "Seleccionar manualmente"
 
 #. module: sale_timesheet_invoice_link
 #: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_link.account_move_view_form_inherit_timesheet_link
 msgid "There is/are"
-msgstr ""
+msgstr "Hay"
 
 #. module: sale_timesheet_invoice_link
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_link.field_account_bank_statement_line__timesheet_alert_dismissed
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_link.field_account_move__timesheet_alert_dismissed
 msgid "Timesheet Alert Dismissed"
-msgstr ""
+msgstr "Alerta de partes descartada"
 
 #. module: sale_timesheet_invoice_link
 #: model:ir.model.fields,help:sale_timesheet_invoice_link.field_account_bank_statement_line__timesheet_pending_ids
@@ -86,8 +89,10 @@ msgid ""
 "Timesheets linked to this invoice's SO lines that are not yet linked to any "
 "non-cancelled invoice"
 msgstr ""
+"Partes de horas vinculados a las líneas de pedido de esta factura que aún no "
+"están vinculados a ninguna factura no cancelada"
 
 #. module: sale_timesheet_invoice_link
 #: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_link.account_move_view_form_inherit_timesheet_link
 msgid "timesheet(s) not linked to this invoice yet."
-msgstr ""
+msgstr "partes de horas no vinculados a esta factura todavía."

--- a/sale_timesheet_invoice_link/models/__init__.py
+++ b/sale_timesheet_invoice_link/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/sale_timesheet_invoice_link/models/account_move.py
+++ b/sale_timesheet_invoice_link/models/account_move.py
@@ -1,0 +1,71 @@
+# Copyright 2024 Moduon Team S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+from odoo import api, fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    timesheet_pending_ids = fields.One2many(
+        comodel_name="account.analytic.line",
+        compute="_compute_timesheet_pending_ids",
+        string="Pending Timesheets",
+        help="Timesheets linked to this invoice's SO lines that are not yet "
+        "linked to any non-cancelled invoice",
+    )
+    timesheet_pending_count = fields.Integer(
+        string="Pending Timesheets Count",
+        compute="_compute_timesheet_pending_ids",
+    )
+    timesheet_alert_dismissed = fields.Boolean(
+        default=False,
+        help="If unchecked, shows a warning alert about unlinked timesheets",
+    )
+
+    @api.depends("invoice_line_ids.sale_line_ids")
+    def _compute_timesheet_pending_ids(self):
+        self.timesheet_pending_ids = False
+        self.timesheet_pending_count = 0
+        for invoice in self.filtered_domain([("move_type", "=", "out_invoice")]):
+            so_lines = invoice.invoice_line_ids.sale_line_ids
+            if not so_lines:
+                continue
+            domain = self.env["account.move.line"]._timesheet_domain_get_invoiced_lines(
+                so_lines
+            )
+            pending = self.env["account.analytic.line"].search(domain)
+            invoice.timesheet_pending_ids = pending
+            invoice.timesheet_pending_count = len(pending)
+
+    def action_link_timesheets(self):
+        self.ensure_one()
+        self.timesheet_pending_ids.write({"timesheet_invoice_id": self.id})
+        self.timesheet_alert_dismissed = True
+
+    def action_dismiss_timesheet_alert(self):
+        self.ensure_one()
+        self.timesheet_alert_dismissed = True
+
+    def action_select_timesheets(self):
+        self.ensure_one()
+        pending = self.timesheet_pending_ids
+        if not pending:
+            return
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Select Timesheets to Link",
+            "res_model": "account.analytic.line",
+            "view_mode": "list,form",
+            "domain": [("id", "in", pending.ids)],
+            "context": {
+                "default_timesheet_invoice_id": self.id,
+            },
+        }
+
+    def button_draft(self):
+        res = super().button_draft()
+        self.filtered(
+            lambda m: m.move_type == "out_invoice"
+        ).timesheet_alert_dismissed = False
+        return res

--- a/sale_timesheet_invoice_link/readme/CONTRIBUTORS.md
+++ b/sale_timesheet_invoice_link/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 -   Jairo Llopis ([Moduon](https://www.moduon.team/))
+-   Emilio Pascual ([Moduon](https://www.moduon.team/))

--- a/sale_timesheet_invoice_link/readme/DESCRIPTION.md
+++ b/sale_timesheet_invoice_link/readme/DESCRIPTION.md
@@ -1,3 +1,7 @@
 This module extends the functionality of timesheets to support linking them to
 preexisting invoices and to allow you to anticipate invoicing, even before the
 work hours are actually done.
+
+It also adds a warning alert on invoices that detects timesheets linked to the
+invoice's sale order lines that are not yet linked to any invoice, allowing you
+to link them all at once or select them manually.

--- a/sale_timesheet_invoice_link/readme/USAGE.md
+++ b/sale_timesheet_invoice_link/readme/USAGE.md
@@ -4,3 +4,13 @@ To use this module, you need to:
 1. Select the list view.
 1. Click on the icon in the top-right corner and display the column *Invoice*.
 1. Link the timesheet lines with the invoices you want from the same customer.
+
+Additionally, when you open an invoice that has timesheets linked to its sale
+order lines but not yet linked to the invoice itself, a warning alert will
+appear at the top of the invoice form. From there you can:
+
+- Click **Link All** to automatically link all pending timesheets to this
+  invoice.
+- Click **Select Manually** to open a filtered list of pending timesheets where
+  you can select specific ones and click **Link to Invoice**.
+- Click **Dismiss** to hide the alert for this invoice.

--- a/sale_timesheet_invoice_link/static/description/index.html
+++ b/sale_timesheet_invoice_link/static/description/index.html
@@ -378,6 +378,9 @@ ul.auto-toc {
 <p>This module extends the functionality of timesheets to support linking
 them to preexisting invoices and to allow you to anticipate invoicing,
 even before the work hours are actually done.</p>
+<p>It also adds a warning alert on invoices that detects timesheets linked
+to the invoice’s sale order lines that are not yet linked to any
+invoice, allowing you to link them all at once or select them manually.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.
@@ -429,6 +432,17 @@ manually and not even when the invoice was already done in the past.</p>
 <li>Link the timesheet lines with the invoices you want from the same
 customer.</li>
 </ol>
+<p>Additionally, when you open an invoice that has timesheets linked to its
+sale order lines but not yet linked to the invoice itself, a warning
+alert will appear at the top of the invoice form. From there you can:</p>
+<ul class="simple">
+<li>Click <strong>Link All</strong> to automatically link all pending timesheets to
+this invoice.</li>
+<li>Click <strong>Select Manually</strong> to open a filtered list of pending
+timesheets where you can select specific ones and click <strong>Link to
+Invoice</strong>.</li>
+<li>Click <strong>Dismiss</strong> to hide the alert for this invoice.</li>
+</ul>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h2><a class="toc-backref" href="#toc-entry-4">Known issues / Roadmap</a></h2>
@@ -457,6 +471,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-8">Contributors</a></h3>
 <ul class="simple">
 <li>Jairo Llopis (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
+<li>Emilio Pascual (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/sale_timesheet_invoice_link/tests/__init__.py
+++ b/sale_timesheet_invoice_link/tests/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+from . import test_invoice_link

--- a/sale_timesheet_invoice_link/tests/test_invoice_link.py
+++ b/sale_timesheet_invoice_link/tests/test_invoice_link.py
@@ -1,0 +1,288 @@
+# Copyright 2024 Moduon Team S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+from odoo.tests import common
+
+
+class TestInvoiceLink(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_hour = cls.env.ref("uom.product_uom_hour")
+        Partner = cls.env["res.partner"]
+        Employee = cls.env["hr.employee"]
+        AccountAccount = cls.env["account.account"]
+        AccountPlan = cls.env["account.analytic.plan"]
+        Project = cls.env["project.project"]
+        Product = cls.env["product.product"]
+        SaleOrder = cls.env["sale.order"]
+        SaleOrderLine = cls.env["sale.order.line"]
+
+        cls.analytic_plan = AccountPlan.create({"name": "Plan Test"})
+        cls.analytic_account = cls.env["account.analytic.account"].create(
+            {
+                "name": "Test AA",
+                "code": "AA-TEST",
+                "plan_id": cls.analytic_plan.id,
+            }
+        )
+        cls.account_expense = AccountAccount.create(
+            {
+                "code": "EXP",
+                "name": "Expense",
+                "account_type": "expense_direct_cost",
+            }
+        )
+        cls.account_income = AccountAccount.create(
+            {
+                "code": "INC",
+                "name": "Income",
+                "account_type": "income",
+            }
+        )
+        cls.account_receivable = AccountAccount.create(
+            {
+                "code": "REC",
+                "name": "Receivable",
+                "account_type": "asset_receivable",
+                "reconcile": True,
+            }
+        )
+        cls.account_payable = AccountAccount.create(
+            {
+                "code": "PAY",
+                "name": "Payable",
+                "account_type": "liability_payable",
+                "reconcile": True,
+            }
+        )
+        cls.partner = Partner.create(
+            {
+                "name": "Test Partner",
+                "email": "test@example.com",
+                "property_account_receivable_id": cls.account_receivable.id,
+                "property_account_payable_id": cls.account_payable.id,
+            }
+        )
+        cls.employee = Employee.create({"name": "Test Employee", "hourly_cost": 50})
+        cls.project = Project.create(
+            {
+                "name": "Test Project",
+                "allow_timesheets": True,
+                "account_id": cls.analytic_account.id,
+                "allow_billable": True,
+            }
+        )
+        # Service product with fixed price (not timesheet delivery)
+        cls.product_fixed = Product.create(
+            {
+                "name": "Fixed Service",
+                "type": "service",
+                "invoice_policy": "order",
+                "service_type": "manual",
+                "service_tracking": "task_global_project",
+                "project_id": cls.project.id,
+                "uom_id": cls.uom_hour.id,
+                "standard_price": 30,
+                "list_price": 100,
+                "property_account_income_id": cls.account_income.id,
+                "taxes_id": False,
+            }
+        )
+        # Service product with timesheet delivery (should auto-link)
+        cls.product_timesheet = Product.create(
+            {
+                "name": "Timesheet Service",
+                "type": "service",
+                "invoice_policy": "delivery",
+                "service_type": "timesheet",
+                "service_tracking": "task_global_project",
+                "project_id": cls.project.id,
+                "uom_id": cls.uom_hour.id,
+                "standard_price": 30,
+                "list_price": 100,
+                "property_account_income_id": cls.account_income.id,
+                "taxes_id": False,
+            }
+        )
+        # Create SO with fixed price line
+        cls.sale_order = SaleOrder.create(
+            {
+                "partner_id": cls.partner.id,
+                "partner_invoice_id": cls.partner.id,
+                "partner_shipping_id": cls.partner.id,
+            }
+        )
+        cls.so_line_fixed = SaleOrderLine.create(
+            {
+                "order_id": cls.sale_order.id,
+                "name": cls.product_fixed.name,
+                "product_id": cls.product_fixed.id,
+                "product_uom_qty": 10,
+                "product_uom_id": cls.uom_hour.id,
+                "price_unit": cls.product_fixed.list_price,
+            }
+        )
+        cls.so_line_timesheet = SaleOrderLine.create(
+            {
+                "order_id": cls.sale_order.id,
+                "name": cls.product_timesheet.name,
+                "product_id": cls.product_timesheet.id,
+                "product_uom_qty": 5,
+                "product_uom_id": cls.uom_hour.id,
+                "price_unit": cls.product_timesheet.list_price,
+            }
+        )
+        cls.sale_order.action_confirm()
+        # Get the task created for the fixed price line
+        cls.task_fixed = cls.env["project.task"].search(
+            [("sale_line_id", "=", cls.so_line_fixed.id)]
+        )
+        cls.task_timesheet = cls.env["project.task"].search(
+            [("sale_line_id", "=", cls.so_line_timesheet.id)]
+        )
+
+    def _create_timesheet(self, task, unit_amount=1.0):
+        return self.env["account.analytic.line"].create(
+            {
+                "project_id": task.project_id.id,
+                "task_id": task.id,
+                "name": "Test timesheet entry",
+                "unit_amount": unit_amount,
+                "employee_id": self.employee.id,
+                "account_id": self.project.account_id.id,
+            }
+        )
+
+    def test_pending_timesheets_fixed_price(self):
+        """Timesheets on fixed-price SO lines should appear as pending."""
+        ts = self._create_timesheet(self.task_fixed)
+        self.assertEqual(ts.timesheet_invoice_type, "billable_fixed")
+        # Create invoice manually
+        invoice = self.sale_order._create_invoices()
+        self.assertTrue(invoice)
+        self.assertEqual(invoice.timesheet_pending_count, 1)
+        self.assertIn(ts, invoice.timesheet_pending_ids)
+
+    def test_pending_timesheets_timesheet_delivery(self):
+        """Timesheets on timesheet-delivery SO lines should NOT be pending
+        (they get auto-linked by standard flow)."""
+        ts = self._create_timesheet(self.task_timesheet)
+        self.assertEqual(ts.timesheet_invoice_type, "billable_time")
+        invoice = self.sale_order._create_invoices()
+        self.assertTrue(invoice)
+        # The timesheet should be auto-linked, so not pending
+        self.assertEqual(invoice.timesheet_pending_count, 0)
+        self.assertTrue(ts.timesheet_invoice_id)
+
+    def test_action_link_timesheets(self):
+        """Link All should set timesheet_invoice_id on all pending."""
+        ts = self._create_timesheet(self.task_fixed)
+        invoice = self.sale_order._create_invoices()
+        self.assertEqual(invoice.timesheet_pending_count, 1)
+        invoice.action_link_timesheets()
+        self.assertTrue(ts.timesheet_invoice_id)
+        self.assertEqual(ts.timesheet_invoice_id, invoice)
+        self.assertTrue(invoice.timesheet_alert_dismissed)
+
+    def test_action_dismiss_timesheet_alert(self):
+        """Dismiss should set timesheet_alert_dismissed."""
+        self._create_timesheet(self.task_fixed)
+        invoice = self.sale_order._create_invoices()
+        self.assertFalse(invoice.timesheet_alert_dismissed)
+        invoice.action_dismiss_timesheet_alert()
+        self.assertTrue(invoice.timesheet_alert_dismissed)
+
+    def test_no_pending_when_all_linked(self):
+        """No pending timesheets when all are already linked."""
+        self._create_timesheet(self.task_fixed)
+        invoice = self.sale_order._create_invoices()
+        invoice.action_link_timesheets()
+        self.env.invalidate_all()
+        self.assertEqual(invoice.timesheet_pending_count, 0)
+
+    def test_pending_count_multiple_timesheets(self):
+        """Multiple timesheets should all be counted as pending."""
+        self._create_timesheet(self.task_fixed, 1.0)
+        self._create_timesheet(self.task_fixed, 2.0)
+        self._create_timesheet(self.task_fixed, 3.0)
+        invoice = self.sale_order._create_invoices()
+        self.assertEqual(invoice.timesheet_pending_count, 3)
+
+    def test_no_pending_for_non_out_invoice(self):
+        """Vendor bills should not have pending timesheets."""
+        self._create_timesheet(self.task_fixed)
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.partner.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Test line",
+                            "quantity": 1,
+                            "price_unit": 100,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(invoice.timesheet_pending_count, 0)
+
+    def test_action_select_timesheets(self):
+        """Select Manually should return an action with the right domain."""
+        self._create_timesheet(self.task_fixed)
+        invoice = self.sale_order._create_invoices()
+        action = invoice.action_select_timesheets()
+        self.assertEqual(action["res_model"], "account.analytic.line")
+        self.assertEqual(action["view_mode"], "list,form")
+        self.assertIn("id", action["domain"][0])
+
+    def test_reset_to_draft_after_dismiss(self):
+        """Reset to draft after dismiss should show alert again."""
+        self._create_timesheet(self.task_fixed)
+        invoice = self.sale_order._create_invoices()
+        invoice.action_dismiss_timesheet_alert()
+        self.assertTrue(invoice.timesheet_alert_dismissed)
+        invoice.action_post()
+        invoice.button_draft()
+        self.assertFalse(invoice.timesheet_alert_dismissed)
+        self.assertEqual(invoice.timesheet_pending_count, 1)
+
+    def test_reset_to_draft_after_link_all(self):
+        """Reset to draft after link all: alert reappears but no pending
+        (timesheet is still linked to the draft invoice)."""
+        self._create_timesheet(self.task_fixed)
+        invoice = self.sale_order._create_invoices()
+        invoice.action_link_timesheets()
+        self.env.invalidate_all()
+        self.assertTrue(invoice.timesheet_alert_dismissed)
+        self.assertEqual(invoice.timesheet_pending_count, 0)
+        invoice.action_post()
+        invoice.button_draft()
+        self.assertFalse(invoice.timesheet_alert_dismissed)
+        self.assertEqual(invoice.timesheet_pending_count, 0)
+
+    def test_reset_to_draft_no_pending(self):
+        """Reset to draft without pending timesheets should not show alert."""
+        invoice = self.sale_order._create_invoices()
+        self.assertEqual(invoice.timesheet_pending_count, 0)
+        invoice.action_post()
+        invoice.button_draft()
+        self.assertFalse(invoice.timesheet_alert_dismissed)
+        self.assertEqual(invoice.timesheet_pending_count, 0)
+
+    def test_reset_to_draft_with_new_timesheet_after_link_all(self):
+        """New timesheet after link all + post should appear pending on draft."""
+        self._create_timesheet(self.task_fixed)
+        invoice = self.sale_order._create_invoices()
+        invoice.action_link_timesheets()
+        self.env.invalidate_all()
+        self.assertEqual(invoice.timesheet_pending_count, 0)
+        invoice.action_post()
+        self._create_timesheet(self.task_fixed)
+        invoice.button_draft()
+        self.assertFalse(invoice.timesheet_alert_dismissed)
+        self.assertEqual(invoice.timesheet_pending_count, 1)

--- a/sale_timesheet_invoice_link/views/account_move_view.xml
+++ b/sale_timesheet_invoice_link/views/account_move_view.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Moduon Team S.L.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0) -->
+<data>
+    <record id="account_move_view_form_inherit_timesheet_link" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.timesheet.link</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="before">
+                <div
+                    class="alert alert-warning w-100 d-flex align-items-center gap-1"
+                    role="alert"
+                    invisible="not timesheet_pending_count or timesheet_alert_dismissed"
+                >
+                    <span>
+                        There is/are
+                        <field name="timesheet_pending_count" />
+                        timesheet(s) not linked to this invoice yet.
+                    </span>
+                    <button
+                        name="action_link_timesheets"
+                        string="Link All"
+                        type="object"
+                        class="btn btn-primary btn-sm ms-2"
+                    />
+                    <button
+                        name="action_select_timesheets"
+                        string="Select Manually"
+                        type="object"
+                        class="btn btn-secondary btn-sm ms-2"
+                    />
+                    <button
+                        name="action_dismiss_timesheet_alert"
+                        string="Dismiss"
+                        type="object"
+                        class="btn btn-sm ms-2"
+                        title="Dismiss this alert"
+                    />
+                </div>
+            </div>
+        </field>
+    </record>
+</data>


### PR DESCRIPTION
After invoicing a sale order with fixed price, milestone, or manual billing policies, timesheets are never linked to the invoice automatically. This adds a warning alert on the invoice form that detects unlinked timesheets and offers "Link All", "Select Manually", or "Dismiss" actions.

@chienandalu @rafaelbn @Gelojr please review it. Thank you.

MT-14588 @moduon