### PR TITLE
[18.0][FIX] hr_timesheet_sheet_attendance: make _check_timesheet multi-record safe

### DIFF
--- a/hr_timesheet_sheet_attendance/models/hr_attendance.py
+++ b/hr_timesheet_sheet_attendance/models/hr_attendance.py
@@ -71,19 +71,23 @@ class HrAttendance(models.Model):
         """- Restrict to create attendance in confirmed timesheet-sheet
         - Restrict to add attendance date outside the current
         timesheet dates"""
-        timesheet = self.sheet_id
-        if not timesheet:
-            return
-        if timesheet and timesheet.state != "draft":
-            raise UserError(
-                _(
-                    "You can not enter an attendance in a submitted timesheet. "
-                    + "Ask your manager to reset it before adding attendance."
+        for attendance in self:
+            timesheet = attendance.sheet_id
+            if not timesheet:
+                continue
+            if timesheet.state != "draft":
+                raise UserError(
+                    _(
+                        "You can not enter an attendance in a submitted timesheet. "
+                        + "Ask your manager to reset it before adding attendance."
+                    )
                 )
+            checkin_tz_date = attendance._get_attendance_employee_tz(
+                date=attendance.check_in
             )
-        else:
-            checkin_tz_date = self._get_attendance_employee_tz(date=self.check_in)
-            checkout_tz_date = self._get_attendance_employee_tz(date=self.check_out)
+            checkout_tz_date = attendance._get_attendance_employee_tz(
+                date=attendance.check_out
+            )
             if (
                 (
                     timesheet.date_start > checkin_tz_date

--- a/hr_timesheet_sheet_attendance/tests/test_hr_attendance.py
+++ b/hr_timesheet_sheet_attendance/tests/test_hr_attendance.py
@@ -64,6 +64,45 @@ class TestHrAttendance(HrTimesheetTestCases):
                 }
             )
 
+    def test_04_check_timesheet_multi_record(self):
+        # Odoo passes the whole created recordset to the constraint, so
+        # creating several attendances at once must not raise
+        # "Expected singleton".
+        self.attendance_1.check_out = datetime.datetime(2018, 12, 12, 13, 0, 0)
+        attendances = self.env["hr.attendance"].create(
+            [
+                {
+                    "employee_id": self.employee.id,
+                    "check_in": datetime.datetime(2018, 12, 12, 14, 0, 0),
+                    "check_out": datetime.datetime(2018, 12, 12, 15, 0, 0),
+                },
+                {
+                    "employee_id": self.employee.id,
+                    "check_in": datetime.datetime(2018, 12, 12, 16, 0, 0),
+                    "check_out": datetime.datetime(2018, 12, 12, 17, 0, 0),
+                },
+            ]
+        )
+        self.assertEqual(len(attendances), 2)
+
+        # A single offending record in a batch is still rejected.
+        with self.assertRaises(UserError):
+            self.env["hr.attendance"].create(
+                [
+                    {
+                        "employee_id": self.employee.id,
+                        "check_in": datetime.datetime(2018, 12, 12, 18, 0, 0),
+                        "check_out": datetime.datetime(2018, 12, 12, 19, 0, 0),
+                    },
+                    {
+                        # Same sheet, but the check-out falls outside its dates.
+                        "employee_id": self.employee.id,
+                        "check_in": datetime.datetime(2018, 12, 12, 20, 0, 0),
+                        "check_out": datetime.datetime(2018, 12, 16, 19, 0, 0),
+                    },
+                ]
+            )
+
     def test_03_check_timesheet(self):
         # check when create attendance out_side the current timesheet date
         with self.assertRaises(UserError):


### PR DESCRIPTION
The constraint read self.sheet_id and self.check_in directly on the recordset. 

Odoo passes the whole affected recordset to @api.constrains, so creating or writing several attendances at once raised "ValueError: Expected singleton" as soon as a timesheet sheet covered the period - hitting list view multi-edit, imports and any module that creates attendances in batch.

Worse, on create the error is raised after the rows are inserted, so a caught exception leaves the attendances in place while everything hooked after core create is skipped.

Iterate over self and add a regression test covering both the valid batch and a batch containing one offending record.