### PR TITLE
[19.0][FIX] hr_timesheet_time_control: Add sudo to copy

### DIFF
--- a/hr_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/hr_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -133,7 +133,7 @@ class TestProjectTimesheetTimeControl(TestProjectTimesheetTimeControlBase):
         with self.assertRaises(exceptions.UserError):
             self.line.button_end_work()
         # Open a new running AAL without wizard
-        running_timer = self.line.copy({"unit_amount": False})
+        running_timer = self.line.sudo().copy({"unit_amount": False})
         # Use resume wizard
         self.line.invalidate_model()
         self.assertEqual(self.line.show_time_control, "resume")
@@ -171,8 +171,8 @@ class TestProjectTimesheetTimeControl(TestProjectTimesheetTimeControlBase):
 
     def test_error_multiple_running_timers(self):
         """If there are multiple running timers, I don't know which to stop."""
-        self.line.copy({})
-        self.line.copy({})
+        self.line.sudo().copy({})
+        self.line.sudo().copy({})
         self.line.button_end_work()
         resume_action = self.line.button_resume_work()
         with self.assertRaises(exceptions.UserError):
@@ -182,7 +182,7 @@ class TestProjectTimesheetTimeControl(TestProjectTimesheetTimeControlBase):
     def test_project_time_control_flow(self):
         """Test project.project time controls."""
         # Resuming a project will try to find lines without task
-        line_without_task = self.line.copy(
+        line_without_task = self.line.sudo().copy(
             {"task_id": False, "project_id": self.project.id, "name": "No task here"}
         )
         self.assertFalse(line_without_task.unit_amount)
@@ -280,7 +280,7 @@ class TestProjectTimesheetTimeControl(TestProjectTimesheetTimeControlBase):
         self.assertEqual(len(new_line), 1)
 
     def test_start_end_time(self):
-        line = self.line.copy(
+        line = self.line.sudo().copy(
             {"task_id": False, "project_id": self.project.id, "name": "No task here"}
         )
         line.date_time = datetime(2020, 8, 1, 10, 0, 0)

--- a/hr_timesheet_time_control/wizards/hr_timesheet_switch.py
+++ b/hr_timesheet_time_control/wizards/hr_timesheet_switch.py
@@ -188,7 +188,7 @@ class HrTimesheetSwitch(models.TransientModel):
         ).running_timer_id.button_end_work()
         # Start new timer
         if self.analytic_line_id:
-            new = self.analytic_line_id.copy(self._prepare_copy_values(self))
+            new = self.analytic_line_id.sudo().copy(self._prepare_copy_values(self))
         else:
             fields = self.env["account.analytic.line"]._fields.keys()
             vals = self.env["account.analytic.line"].default_get(fields)


### PR DESCRIPTION
If the `account_analytic_tag` module is installed, the following situation can occur:

* A **Billing User** adds analytic tags to **User2**'s timesheets.
* **User2** then tries to start a timer from one of those timesheets, which raises the following error:

```text
Failed to read field account.analytic.line.tag_ids
You are not allowed to access 'Analytic Tags' (account.analytic.tag) records.

This operation is allowed for the following groups:
    - Accounting/Administrator
    - Analytic Accounting

Contact your administrator to request access if necessary.
```

This happens because the `copy` method does not filter out fields for which the current user lacks access rights (and it should not). Adding `sudo()` to the `copy` call avoids this issue. This also makes the implementation more robust, preventing similar errors if additional restricted fields are added to the model in the future.

@Tecnativa TT63888
@adasatorres-tecnativa @pedrobaeza 